### PR TITLE
Issue #20 - TestExtension: add auto-veto options

### DIFF
--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/TestExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/TestExtension.java
@@ -12,6 +12,7 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 
 import javax.swing.JComponent;
@@ -44,6 +45,9 @@ public class TestExtension extends CryptTextExtension {
 
     private static final Logger log = Logger.getLogger(TestExtension.class.getName());
 
+    private static final String AUTO_VETO_LOAD_PROP = "TestExtension.Options.autoVetoLoad";
+    private static final String AUTO_VETO_SAVE_PROP = "TestExtension.Options.autoVetoSave";
+
     private final AppExtensionInfo extInfo;
     private final EnhancedAction logDumpAction = new LogDumpAction();
 
@@ -72,6 +76,9 @@ public class TestExtension extends CryptTextExtension {
                                         logDumpAction)
                           .setHelpText("Generates a diagnostic log dump"));
 
+        props.add(new BooleanProperty(AUTO_VETO_LOAD_PROP, "Veto all load operations", false));
+        props.add(new BooleanProperty(AUTO_VETO_SAVE_PROP, "Veto all save operations", false));
+
         return props;
     }
 
@@ -94,12 +101,22 @@ public class TestExtension extends CryptTextExtension {
 
     @Override
     public boolean fileWillLoad(File toLoad) {
+        boolean shouldVeto = getBooleanProp(AUTO_VETO_LOAD_PROP);
+        if (shouldVeto) {
+            log.info("fileWillLoad: vetoing load of " + toLoad.getAbsolutePath());
+            return false;
+        }
         log.info("fileWillLoad: " + toLoad.getAbsolutePath());
         return true;
     }
 
     @Override
     public boolean fileWillSave(File toSave, String newContents, File destFile) {
+        boolean shouldVeto = getBooleanProp(AUTO_VETO_SAVE_PROP);
+        if (shouldVeto) {
+            log.info("fileWillSave: vetoing save of " + toSave.getAbsolutePath() + " -> " + destFile.getAbsolutePath());
+            return false;
+        }
         log.info("fileWillSave: " + toSave.getAbsolutePath() + " -> " + destFile.getAbsolutePath());
         return true;
     }
@@ -137,6 +154,21 @@ public class TestExtension extends CryptTextExtension {
     @Override
     public TabStateManager getTabStateManager() {
         return new TestTabStateManager();
+    }
+
+    /**
+     * Quick shorthand method to look up the given boolean property and return its current value.
+     * You'll get false if the named property is not found.
+     */
+    private boolean getBooleanProp(String propName) {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(propName);
+        if (prop instanceof BooleanProperty) {
+            return ((BooleanProperty)prop).getValue();
+        }
+        else {
+            log.warning("Expected boolean property for name: " + propName + ", but got: " + prop);
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/ui/actions/OpenFileAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/OpenFileAction.java
@@ -36,6 +36,13 @@ public class OpenFileAction extends EnhancedAction {
             AppConfig.getInstance().setLastBrowseDirectory(selectedFile.getParentFile());
             try {
                 Text text = MainWindow.getInstance().getTextManager().fromFile(selectedFile);
+
+                // TextManager.fromFile() can return null if an extension vetoes the load.
+                if (text == null) {
+                    // No need to log this - presumably the vetoing extension has already notified the user.
+                    return;
+                }
+
                 MainWindow.getInstance().getEditorTabPane().clearIfScratch();
                 MainWindow.getInstance().getEditorTabPane().newTextTab(text, selectedFile.getName());
             }

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.0 - [TODO release date here] Initial release
+  #20 - TestExtension: add auto-veto options
   #10 - Add built-in (but hidden) TestExtension
   #7 - Add support for command-line arguments
   #5 - Add main editor tab view with basic configuration options.


### PR DESCRIPTION
This PR addresses issue #20 by adding auto-veto options to the TestExtension, so that the vetoing of load and save operations can be tested. 

After making this change, I found and fixed a bug in OpenFileAction, where we weren't properly handling a vetoed file load operation.

Closes #20 