### PR TITLE
Issue #37 - editor color themes

### DIFF
--- a/src/main/java/ca/corbett/crypttext/AppConfig.java
+++ b/src/main/java/ca/corbett/crypttext/AppConfig.java
@@ -2,6 +2,7 @@ package ca.corbett.crypttext;
 
 import ca.corbett.crypttext.extensions.CryptTextExtension;
 import ca.corbett.crypttext.extensions.CryptTextExtensionManager;
+import ca.corbett.crypttext.ui.ColorTheme;
 import ca.corbett.crypttext.ui.actions.AboutAction;
 import ca.corbett.crypttext.ui.actions.CryptAction;
 import ca.corbett.crypttext.ui.actions.ExitAction;
@@ -15,18 +16,30 @@ import ca.corbett.crypttext.ui.actions.SaveAction;
 import ca.corbett.crypttext.ui.actions.SaveAsAction;
 import ca.corbett.crypttext.ui.actions.SaveUnencryptedAction;
 import ca.corbett.extensions.AppProperties;
+import ca.corbett.extras.LookAndFeelManager;
+import ca.corbett.extras.gradient.ColorSelectionType;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
+import ca.corbett.extras.properties.ColorProperty;
 import ca.corbett.extras.properties.DirectoryProperty;
+import ca.corbett.extras.properties.EnumProperty;
 import ca.corbett.extras.properties.FontProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.extras.properties.LookAndFeelProperty;
+import ca.corbett.extras.properties.PropertyFormFieldChangeListener;
+import ca.corbett.extras.properties.PropertyFormFieldValueChangedEvent;
+import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.fields.CheckBoxField;
+import ca.corbett.forms.fields.ColorField;
+import ca.corbett.forms.fields.ComboField;
 import com.formdev.flatlaf.FlatLightLaf;
 
 import javax.swing.Action;
+import java.awt.Color;
 import java.awt.Font;
+import java.awt.Frame;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,6 +106,12 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private BooleanProperty showLineNumbersProp;
     private FontProperty editorFontProp;
     private FontProperty gutterFontProp;
+    private BooleanProperty overrideLafProp;
+    private EnumProperty<ColorTheme> editorThemeProp;
+    private ColorProperty editorBackgroundColorProp;
+    private ColorProperty editorForegroundColorProp;
+    private ColorProperty gutterBackgroundColorProp;
+    private ColorProperty gutterForegroundColorProp;
 
     // These will be used in the menu bar and with KeyStrokeManager:
     // (they could also be added to buttons or popup menus as needed)
@@ -118,6 +137,20 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
 
     public static AppConfig getInstance() {
         return SingletonHolder.INSTANCE;
+    }
+
+    /**
+     * Overridden so we can set the initial enabled/disabled state our properties.
+     */
+    @Override
+    public boolean showPropertiesDialog(Frame owner) {
+        boolean isCustom = overrideLafProp.getValue();
+        editorThemeProp.setInitiallyEditable(isCustom);
+        editorBackgroundColorProp.setInitiallyEditable(isCustom);
+        editorForegroundColorProp.setInitiallyEditable(isCustom);
+        gutterBackgroundColorProp.setInitiallyEditable(isCustom);
+        gutterForegroundColorProp.setInitiallyEditable(isCustom);
+        return super.showPropertiesDialog(owner);
     }
 
     /**
@@ -292,6 +325,82 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     }
 
     /**
+     * Returns the configured editor background color.
+     * This will come from the current Look and Feel if we are not set to override it.
+     * Otherwise, this is the user-selected background color.
+     */
+    public Color getEditorBackgroundColor() {
+        if (overrideLafProp.getValue()) {
+            return editorBackgroundColorProp.getSolidColor();
+        }
+        else {
+            return LookAndFeelManager.getLafColor("Panel.background", Color.LIGHT_GRAY);
+        }
+    }
+
+    /**
+     * Returns the configured editor foreground color.
+     * This will come from the current Look and Feel if we are not set to override it.
+     * Otherwise, this is the user-selected foreground color.
+     */
+    public Color getEditorForegroundColor() {
+        if (overrideLafProp.getValue()) {
+            return editorForegroundColorProp.getSolidColor();
+        }
+        else {
+            return LookAndFeelManager.getLafColor("Panel.foreground", Color.BLACK);
+        }
+    }
+
+    /**
+     * Returns the configured gutter background color (for line numbers).
+     * This will come from the current Look and Feel if we are not set to override it
+     * - in this case, we will attempt to be a little smarter and return a color that is
+     * slightly offset from the regular background color, to provide some visual contrast
+     * while still fitting in with the overall theme.
+     */
+    public Color getGutterBackgroundColor() {
+        if (overrideLafProp.getValue()) {
+            return gutterBackgroundColorProp.getSolidColor();
+        }
+        else {
+            // We want to offset the gutter background slightly, but we need
+            // to be careful, because the current LaF might be light or dark:
+            Color bg = LookAndFeelManager.getLafColor("Panel.background", Color.LIGHT_GRAY);
+            if (LookAndFeelManager.isDark()) {
+                bg = bg.brighter();
+            }
+            else {
+                bg = bg.darker();
+            }
+            return bg;
+        }
+    }
+
+    /**
+     * Returns the configured gutter foreground color (for line numbers).
+     * This will come from the current Look and Feel if we are not set to override it
+     * - in this case, we will attempt to be a little smarter and return a color that is
+     * slightly offset from the regular foreground color, to provide some visual contrast
+     * while still fitting in with the overall theme.
+     */
+    public Color getGutterForegroundColor() {
+        if (overrideLafProp.getValue()) {
+            return gutterForegroundColorProp.getSolidColor();
+        }
+        else {
+            Color fg = LookAndFeelManager.getLafColor("Panel.foreground", Color.BLACK);
+            if (LookAndFeelManager.isDark()) {
+                fg = fg.brighter();
+            }
+            else {
+                fg = fg.darker();
+            }
+            return fg;
+        }
+    }
+
+    /**
      * This is where you can define the configuration properties for your application.
      * These properties will be displayed in the PropertiesDialog, and persisted
      * to the properties file automatically.
@@ -363,6 +472,59 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
                                                   "Show line numbers in editor",
                                                   true);
         props.add(showLineNumbersProp);
+
+        overrideLafProp = new BooleanProperty("UI.Editor.overrideLaF",
+                                              "Override Look and Feel with custom editor colors",
+                                              false);
+        props.add(overrideLafProp);
+
+        editorThemeProp = new EnumProperty<>("UI.Editor.colorTheme",
+                                             "Set from theme:",
+                                             ColorTheme.MATRIX);
+        editorThemeProp.addFormFieldChangeListener(this::setColorTheme);
+        props.add(editorThemeProp);
+
+        editorBackgroundColorProp = new ColorProperty("UI.Editor.editorBackground",
+                                                      "Editor bg:",
+                                                      ColorSelectionType.SOLID)
+                .setSolidColor(ColorTheme.MATRIX.getEditorBackground());
+        editorBackgroundColorProp.addLeftPadding(20); // Indent a little bit
+        props.add(editorBackgroundColorProp);
+
+        editorForegroundColorProp = new ColorProperty("UI.Editor.editorForeground",
+                                                      "Editor fg:",
+                                                      ColorSelectionType.SOLID)
+                .setSolidColor(ColorTheme.MATRIX.getEditorForeground());
+        editorForegroundColorProp.addLeftPadding(20); // Indent a little bit
+        props.add(editorForegroundColorProp);
+
+        gutterBackgroundColorProp = new ColorProperty("UI.Editor.gutterBackground",
+                                                      "Gutter bg:",
+                                                      ColorSelectionType.SOLID)
+                .setSolidColor(ColorTheme.MATRIX.getGutterBackground());
+        gutterBackgroundColorProp.addLeftPadding(20); // Indent a little bit
+        props.add(gutterBackgroundColorProp);
+
+        gutterForegroundColorProp = new ColorProperty("UI.Editor.gutterForeground",
+                                                      "Gutter fg:",
+                                                      ColorSelectionType.SOLID)
+                .setSolidColor(ColorTheme.MATRIX.getGutterForeground());
+        gutterForegroundColorProp.addLeftPadding(20); // Indent a little bit
+        props.add(gutterForegroundColorProp);
+
+        // Set up a listener to ensure proper enabled/disabled state:
+        overrideLafProp.addFormFieldChangeListener(new PropertyFormFieldChangeListener() {
+            @Override
+            public void valueChanged(PropertyFormFieldValueChangedEvent event) {
+                boolean isCustom = ((CheckBoxField)event.formField()).isChecked();
+                FormPanel fp = event.formPanel();
+                fp.getFormField(editorThemeProp.getFullyQualifiedName()).setEnabled(isCustom);
+                fp.getFormField(editorBackgroundColorProp.getFullyQualifiedName()).setEnabled(isCustom);
+                fp.getFormField(editorForegroundColorProp.getFullyQualifiedName()).setEnabled(isCustom);
+                fp.getFormField(gutterBackgroundColorProp.getFullyQualifiedName()).setEnabled(isCustom);
+                fp.getFormField(gutterForegroundColorProp.getFullyQualifiedName()).setEnabled(isCustom);
+            }
+        });
 
         return props;
     }
@@ -473,5 +635,29 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
                           .setAllowBlank(true));
 
         return props;
+    }
+
+    /**
+     * Invoked when the color theme chooser is modified. Will look up all relevant
+     * color fields and set all their values according to the selected scheme.
+     */
+    private void setColorTheme(PropertyFormFieldValueChangedEvent event) {
+        FormPanel fp = event.formPanel();
+        if (fp == null) {
+            return;
+        }
+
+        // Look up all our generated form fields:
+        ColorField editorBgField = (ColorField)fp.getFormField(editorBackgroundColorProp.getFullyQualifiedName());
+        ColorField editorFgField = (ColorField)fp.getFormField(editorForegroundColorProp.getFullyQualifiedName());
+        ColorField gutterBgField = (ColorField)fp.getFormField(gutterBackgroundColorProp.getFullyQualifiedName());
+        ColorField gutterFgField = (ColorField)fp.getFormField(gutterForegroundColorProp.getFullyQualifiedName());
+
+        // Set them all!
+        ColorTheme theme = (ColorTheme)((ComboField<?>)event.formField()).getSelectedItem();
+        editorBgField.setColor(theme.getEditorBackground());
+        editorFgField.setColor(theme.getEditorForeground());
+        gutterBgField.setColor(theme.getGutterBackground());
+        gutterFgField.setColor(theme.getGutterForeground());
     }
 }

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/StatusBarExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/StatusBarExtension.java
@@ -9,6 +9,7 @@ import ca.corbett.crypttext.ui.MainWindow;
 import ca.corbett.crypttext.ui.UIReloadable;
 import ca.corbett.crypttext.ui.actions.UIReloadAction;
 import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
@@ -19,6 +20,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
@@ -52,6 +54,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
 
     private final AppExtensionInfo extInfo;
     private final StatusBarComponent statusBar;
+    private final LaFChangeListener lafChangeListener = new LaFChangeListener();
 
     public StatusBarExtension() {
         extInfo = new AppExtensionInfo.Builder("Status bar")
@@ -76,6 +79,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
         MainWindow.getInstance().getEditorTabPane().addChangeListener(this);
 
         // Listen for UI updates, so we can update our cosmetic properties:
+        LookAndFeelManager.addChangeListener(lafChangeListener);
         UIReloadAction.getInstance().registerReloadable(this);
 
         // Force an initial update to pick up our property values now:
@@ -90,6 +94,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
         // Stop listening for events:
         MainWindow.getInstance().getEditorTabPane().removeChangeListener(this);
         UIReloadAction.getInstance().unregisterReloadable(this);
+        LookAndFeelManager.removeChangeListener(lafChangeListener);
         statusBar.setCurrentTab(null); // clear any listeners our status bar has, if any
     }
 
@@ -359,6 +364,21 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
         @Override
         public void onContentChange(String newContent) {
             updateTextStatsLabel(newContent);
+        }
+    }
+
+    /**
+     * Application startup loads and activates all extensions before setting the
+     * configured Look and Feel. This means that our StatusBar is created before
+     * the LaF is set. So, we need to listen for LaF changes and update the UI
+     * of our StatusBar accordingly when that happens. After initial application
+     * startup, this listener becomes redundant, since our LaF manager will
+     * handle updating all existing windows, but we need this for app startup.
+     */
+    private class LaFChangeListener implements ChangeListener {
+        @Override
+        public void stateChanged(ChangeEvent e) {
+            SwingUtilities.updateComponentTreeUI(statusBar);
         }
     }
 }

--- a/src/main/java/ca/corbett/crypttext/ui/ColorTheme.java
+++ b/src/main/java/ca/corbett/crypttext/ui/ColorTheme.java
@@ -1,0 +1,90 @@
+package ca.corbett.crypttext.ui;
+
+import java.awt.Color;
+
+/**
+ * Cheesy built-in color schemes for users who don't want
+ * to rely on the Look and Feel colors.
+ * <p>
+ * This could be externalized, to avoid hard-coding, but eh... it's
+ * fine for a neat little extra feature that might rarely actually get used.
+ * Relying on the Look and Feel for this stuff is a better option in general,
+ * and CryptText ships with all the extra Look and Feels that come
+ * for free out of the box with swing-extras.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public enum ColorTheme {
+    MATRIX("Matrix",
+           new Color(0, 0, 0),   // Editor background
+           new Color(0, 255, 0), // Editor foreground
+           new Color(0, 50, 0),  // Gutter background
+           new Color(0, 200, 0)  // Gutter foreground
+    ),
+    DARK("Dark",
+         new Color(45, 45, 45),    // Editor background
+         new Color(220, 220, 220), // Editor foreground
+         new Color(60, 60, 60),    // Gutter background
+         new Color(200, 200, 200)  // Gutter foreground
+    ),
+    VERY_DARK("Very dark",
+              new Color(25, 25, 25),    // Editor background
+              new Color(205, 205, 205), // Editor foreground
+              new Color(40, 40, 40),    // Gutter background
+              new Color(180, 180, 180)  // Gutter foreground
+    ),
+    SHADES_OF_GREY("Shades of grey",
+                   new Color(165, 165, 165),    // Editor background
+                   new Color(20, 20, 20), // Editor foreground
+                   new Color(135, 135, 135),    // Gutter background
+                   new Color(60, 60, 60)  // Gutter foreground
+    ),
+    GOT_THE_BLUES("Got the blues",
+                  new Color(30, 30, 60),   // Editor background
+                  new Color(200, 200, 255),// Editor foreground
+                  new Color(20, 20, 50),   // Gutter background
+                  new Color(150, 150, 255) // Gutter foreground
+    ),
+    HOT_DOG_STAND("Hot dog stand", // The obligatory joke option
+                  new Color(60, 30, 30), // Editor background
+                  Color.ORANGE,                   // Editor foreground
+                  new Color(50, 20, 20), // Gutter background
+                  Color.YELLOW                    // Gutter foreground
+    );
+
+    private final String label;
+    private final Color editorBackground;
+    private final Color editorForeground;
+    private final Color gutterBackground;
+    private final Color gutterForeground;
+
+    ColorTheme(String label, Color editorBackground, Color editorForeground, Color gutterBackground, Color gutterForeground) {
+        this.label = label;
+        this.editorBackground = editorBackground;
+        this.editorForeground = editorForeground;
+        this.gutterBackground = gutterBackground;
+        this.gutterForeground = gutterForeground;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+
+    public Color getEditorBackground() {
+        return editorBackground;
+    }
+
+    public Color getEditorForeground() {
+        return editorForeground;
+    }
+
+    public Color getGutterBackground() {
+        return gutterBackground;
+    }
+
+    public Color getGutterForeground() {
+        return gutterForeground;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -118,6 +118,7 @@ public class EditorTab extends JPanel implements UIReloadable {
         isDirty = false;
         tabHeader = new EditorTabHeader(this, name);
         UIReloadAction.getInstance().registerReloadable(this);
+        reloadUI(); // force an immediate update to pick up the correct theme and color scheme
     }
 
     /**
@@ -542,6 +543,10 @@ public class EditorTab extends JPanel implements UIReloadable {
             scrollPane.setRowHeaderView(AppConfig.getInstance().isShowLineNumbers() ? gutter : null);
             textPane.setFont(AppConfig.getInstance().getEditorFont());
             gutter.setLineNumberFont(AppConfig.getInstance().getGutterFont());
+            gutter.updateColors(); // tell our gutter to update its colors based on the current theme
+            textPane.setBackground(AppConfig.getInstance().getEditorBackgroundColor());
+            textPane.setForeground(AppConfig.getInstance().getEditorForegroundColor());
+            repaint();
         }
         finally {
             SwingUtilities.invokeLater(() -> eventsEnabled = true);

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
@@ -6,9 +6,11 @@ import ca.corbett.crypttext.VetoException;
 import ca.corbett.crypttext.extensions.CryptTextExtensionManager;
 import ca.corbett.crypttext.text.Text;
 import ca.corbett.crypttext.text.TextManager;
+import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.MessageUtil;
 
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +49,7 @@ public class EditorTabPane extends JTabbedPane {
 
     public EditorTabPane() {
         this.textManager = buildTextManager();
+        LookAndFeelManager.addChangeListener(e -> SwingUtilities.updateComponentTreeUI(this));
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/ui/LineNumberGutter.java
+++ b/src/main/java/ca/corbett/crypttext/ui/LineNumberGutter.java
@@ -2,6 +2,7 @@ package ca.corbett.crypttext.ui;
 
 
 import ca.corbett.crypttext.AppConfig;
+import ca.corbett.extras.LookAndFeelManager;
 
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
@@ -33,12 +34,11 @@ public class LineNumberGutter extends JPanel implements DocumentListener, CaretL
     private final JTextPane textPane;
     private static final int PADDING = 5;
     private Font lineNumberFont;
+    private Color lineNumberColor;
 
     public LineNumberGutter(JTextPane textPane) {
         this.textPane = textPane;
         lineNumberFont = AppConfig.getInstance().getGutterFont();
-        setBackground(new Color(240, 240, 240)); // hard-coding colors until we get proper themes in place
-        setBorder(BorderFactory.createMatteBorder(0, 0, 0, 1, Color.LIGHT_GRAY));
         textPane.getDocument().addDocumentListener(this);
         textPane.addCaretListener(this);
         // Also revalidate on component resize
@@ -48,6 +48,23 @@ public class LineNumberGutter extends JPanel implements DocumentListener, CaretL
                 repaint();
             }
         });
+        updateColors();
+    }
+
+    /**
+     * Invoke this to force an update of our background and foreground and border
+     * colors based on whatever is currently set in application preferences.
+     */
+    public void updateColors() {
+        Color bg = AppConfig.getInstance().getGutterBackgroundColor();
+        Color fg = AppConfig.getInstance().getGutterForegroundColor();
+        setBackground(bg);
+        lineNumberColor = fg;
+        Color borderColor = LookAndFeelManager.isDark()
+                ? bg.brighter()
+                : bg.darker();
+        setBorder(BorderFactory.createMatteBorder(0, 0, 0, 1, borderColor));
+        repaint();
     }
 
     /**
@@ -84,7 +101,7 @@ public class LineNumberGutter extends JPanel implements DocumentListener, CaretL
         Graphics2D g2 = (Graphics2D)g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setFont(lineNumberFont);
-        g2.setColor(Color.GRAY);
+        g2.setColor(lineNumberColor);
 
         FontMetrics fm = g2.getFontMetrics();
         Rectangle clip = g.getClipBounds();

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.0 - [TODO release date here] Initial release
+  #37 - New option: editor theme selection.
   #33 - New option: editor font selection.
   #30 - New option: show full path in main window title bar.
   #29 - New option: show line numbers in editor.


### PR DESCRIPTION
This PR addresses issue #37 by adding support for custom editor themes and colors.

Changes:
- add new option to override Look and Feel and set custom editor colors
- added options for customizing editor and gutter background and foreground
- fixed bug in StatusBarExtension where Look and Feel might not be set properly at startup
- fixed bug in EditorTabPane where Look and Feel might not be set properly at startup
- added a few built-in color themes (user can ignore these and choose individual colors)
