### PR TITLE
Issue #52 - undo/redo tweaks

### DIFF
--- a/src/main/java/ca/corbett/crypttext/AppConfig.java
+++ b/src/main/java/ca/corbett/crypttext/AppConfig.java
@@ -12,9 +12,11 @@ import ca.corbett.crypttext.ui.actions.LogConsoleAction;
 import ca.corbett.crypttext.ui.actions.NewTabAction;
 import ca.corbett.crypttext.ui.actions.OpenFileAction;
 import ca.corbett.crypttext.ui.actions.PropertiesAction;
+import ca.corbett.crypttext.ui.actions.RedoAction;
 import ca.corbett.crypttext.ui.actions.SaveAction;
 import ca.corbett.crypttext.ui.actions.SaveAsAction;
 import ca.corbett.crypttext.ui.actions.SaveUnencryptedAction;
+import ca.corbett.crypttext.ui.actions.UndoAction;
 import ca.corbett.extensions.AppProperties;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.gradient.ColorSelectionType;
@@ -87,6 +89,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private static final String KEY_SAVE_FILE = KEYSTROKE_PREFIX + "General.saveFile";
     private static final String KEY_SAVE_FILE_AS = KEYSTROKE_PREFIX + "General.saveFileAs";
     private static final String KEY_SAVE_UNENCRYPTED = KEYSTROKE_PREFIX + "General.saveUnencrypted";
+    private static final String KEY_UNDO = KEYSTROKE_PREFIX + "General.undo";
+    private static final String KEY_REDO = KEYSTROKE_PREFIX + "General.redo";
     private static final String KEY_CRYPT = KEYSTROKE_PREFIX + "General.crypt";
     private static final String KEY_FORGET_PASSWORD = KEYSTROKE_PREFIX + "General.forgetPassword";
     private static final String KEY_PROPERTIES = KEYSTROKE_PREFIX + "General.properties";
@@ -102,6 +106,7 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private BooleanProperty enableSingleInstance;
     private BooleanProperty showFullPathInTitleProp;
     private IntegerProperty recentFilesLimitProp;
+    private IntegerProperty undoLimitProp;
     private BooleanProperty enableTabLockIconsProp;
     private IntegerProperty tabIconSizeProp;
     private BooleanProperty closeLastTabExitsProp;
@@ -127,6 +132,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private Action saveFileAction;
     private Action saveFileAsAction;
     private Action saveUnencryptedAction;
+    private Action undoAction;
+    private Action redoAction;
     private Action cryptAction;
     private Action forgetPasswordAction;
     private Action propertiesAction;
@@ -196,6 +203,14 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         return saveUnencryptedAction;
     }
 
+    public Action getUndoAction() {
+        return undoAction;
+    }
+
+    public Action getRedoAction() {
+        return redoAction;
+    }
+
     public Action getCryptAction() {
         return cryptAction;
     }
@@ -237,6 +252,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_SAVE_FILE));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_SAVE_FILE_AS));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_SAVE_UNENCRYPTED));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_UNDO));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_REDO));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_CRYPT));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FORGET_PASSWORD));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_PROPERTIES));
@@ -313,6 +330,13 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
      */
     public boolean isRestoreTabsOnStartup() {
         return restoreTabsOnStartupProp.getValue();
+    }
+
+    /**
+     * Returns the number of undo levels to keep in the undo stack for each editor tab.
+     */
+    public int getUndoLimit() {
+        return undoLimitProp.getValue();
     }
 
     /**
@@ -450,6 +474,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         saveFileAction = new SaveAction();
         saveFileAsAction = new SaveAsAction();
         saveUnencryptedAction = new SaveUnencryptedAction();
+        undoAction = new UndoAction();
+        redoAction = new RedoAction();
         cryptAction = new CryptAction();
         forgetPasswordAction = new ForgetPasswordAction();
         propertiesAction = new PropertiesAction();
@@ -572,6 +598,11 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
                                                        true);
         props.add(restoreTabsOnStartupProp);
 
+        undoLimitProp = new IntegerProperty("UI.Editor tabs.undoLimit",
+                                            "Undo levels:",
+                                            100, 0, 1000, 10);
+        props.add(undoLimitProp);
+
         return props;
     }
 
@@ -621,6 +652,14 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         props.add(new KeyStrokeProperty(KEY_SAVE_UNENCRYPTED, "Save Unencrypted:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+Shift+1"), // "!" for unsafe save.
                                         saveUnencryptedAction)
+                          .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_UNDO, "Undo:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+Z"),
+                                        undoAction)
+                          .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_REDO, "Redo:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+Y"),
+                                        redoAction)
                           .setAllowBlank(true));
         props.add(new KeyStrokeProperty(KEY_CRYPT, "Encrypt/Decrypt:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+D"), // D for "decrypt/crypt" :)

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -184,6 +184,7 @@ public class EditorTab extends JPanel implements UIReloadable {
      * Undoes the last edit in this editor tab, if possible.
      */
     public void undo() {
+        undoableEditListener.flush(); // commit any in-progress group before undoing, so that undo will work as expected
         if (undoManager.canUndo()) {
             undoManager.undo();
         }
@@ -193,6 +194,7 @@ public class EditorTab extends JPanel implements UIReloadable {
      * Redoes the last undone edit in this editor tab, if possible.
      */
     public void redo() {
+        undoableEditListener.flush(); // commit any in-progress group before redoing, so that redo will work as expected
         if (undoManager.canRedo()) {
             undoManager.redo();
         }

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -13,24 +13,17 @@ import ca.corbett.crypttext.ui.actions.UIReloadAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.ScrollUtil;
 
-import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
-import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.event.UndoableEditListener;
 import javax.swing.undo.UndoManager;
 import java.awt.BorderLayout;
-import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -83,7 +76,7 @@ public class EditorTab extends JPanel implements UIReloadable {
     private final LineNumberGutter gutter;
     private final EditorTabHeader tabHeader;
     private final UndoManager undoManager;
-    private final UndoableEditListener undoableEditListener;
+    private final GroupingUndoableEditListener undoableEditListener;
     private String name;
     private Text diskContents;
     private CryptMetadata cryptMetadata;
@@ -126,24 +119,9 @@ public class EditorTab extends JPanel implements UIReloadable {
         this.cryptMetadata = generateCryptMetadata();
         textPane.getDocument().addDocumentListener(new DocListener());
         undoManager = new UndoManager();
-        undoManager.setLimit(100);
-        undoableEditListener = e -> {
-            if (eventsEnabled) {
-                undoManager.addEdit(e.getEdit());
-            }
-        };
+        undoManager.setLimit(AppConfig.getInstance().getUndoLimit());
+        undoableEditListener = new GroupingUndoableEditListener(undoManager);
         textPane.getDocument().addUndoableEditListener(undoableEditListener);
-        KeyStroke undoKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_Z,
-                                                         Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
-        textPane.getInputMap(JComponent.WHEN_FOCUSED).put(undoKeyStroke, "undo");
-        textPane.getActionMap().put("undo", new AbstractAction() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (undoManager.canUndo()) {
-                    undoManager.undo();
-                }
-            }
-        });
         isDirty = false;
         tabHeader = new EditorTabHeader(this, name);
         UIReloadAction.getInstance().registerReloadable(this);
@@ -203,6 +181,24 @@ public class EditorTab extends JPanel implements UIReloadable {
     }
 
     /**
+     * Undoes the last edit in this editor tab, if possible.
+     */
+    public void undo() {
+        if (undoManager.canUndo()) {
+            undoManager.undo();
+        }
+    }
+
+    /**
+     * Redoes the last undone edit in this editor tab, if possible.
+     */
+    public void redo() {
+        if (undoManager.canRedo()) {
+            undoManager.redo();
+        }
+    }
+
+    /**
      * Updates the name of this tab.
      */
     public void setTabName(String newName) {
@@ -248,6 +244,7 @@ public class EditorTab extends JPanel implements UIReloadable {
      */
     public void dispose() {
         UIReloadAction.getInstance().unregisterReloadable(this); // stop listening
+        undoableEditListener.flush(); // commit any pending group and stop the timer
         textPane.getDocument().removeUndoableEditListener(undoableEditListener);
     }
 
@@ -569,6 +566,8 @@ public class EditorTab extends JPanel implements UIReloadable {
         // The fix is to re-enable events inside our own invokeLater, so it is queued AFTER
         // the style-change event and will therefore run after eventsEnabled has been checked.
         eventsEnabled = false;
+        undoableEditListener.setEnabled(false);
+        undoManager.setLimit(AppConfig.getInstance().getUndoLimit());
         try {
             scrollPane.setRowHeaderView(AppConfig.getInstance().isShowLineNumbers() ? gutter : null);
             textPane.setFont(AppConfig.getInstance().getEditorFont());
@@ -579,7 +578,10 @@ public class EditorTab extends JPanel implements UIReloadable {
             repaint();
         }
         finally {
-            SwingUtilities.invokeLater(() -> eventsEnabled = true);
+            SwingUtilities.invokeLater(() -> {
+                eventsEnabled = true;
+                undoableEditListener.setEnabled(true);
+            });
         }
 
         // Note: our EditorTabHeader is updated via MainWindow's reloadUI handler,

--- a/src/main/java/ca/corbett/crypttext/ui/GroupingUndoableEditListener.java
+++ b/src/main/java/ca/corbett/crypttext/ui/GroupingUndoableEditListener.java
@@ -1,0 +1,142 @@
+package ca.corbett.crypttext.ui;
+
+import javax.swing.Timer;
+import javax.swing.event.UndoableEditEvent;
+import javax.swing.event.UndoableEditListener;
+import javax.swing.undo.CompoundEdit;
+import javax.swing.undo.UndoManager;
+import javax.swing.undo.UndoableEdit;
+
+/**
+ * A custom {@link UndoableEditListener} that groups rapid successive edits into a single
+ * logical undo entry. Each time a new edit arrives, a short timer is (re)started. When
+ * the timer fires (i.e. the user has paused typing), the current group is committed to
+ * the {@link UndoManager} as one {@link CompoundEdit}. This means a single Ctrl+Z will
+ * undo the entire burst of keystrokes rather than reversing them one character at a time.
+ *
+ * <p>Style-change events ({@code changedUpdate}) are deliberately ignored because Swing
+ * fires them for font/color changes that should not appear on the undo stack.</p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>, with claude.ai
+ */
+public class GroupingUndoableEditListener implements UndoableEditListener {
+
+    /** Milliseconds of idle time before the current group is committed. */
+    private static final int COMMIT_DELAY_MS = 500;
+
+    private final UndoManager undoManager;
+
+    /**
+     * The compound edit currently being accumulated.
+     * Null means no group is in progress.
+     */
+    private CompoundEdit currentGroup;
+
+    /**
+     * Timer that commits {@link #currentGroup} after {@link #COMMIT_DELAY_MS} ms of
+     * inactivity. The timer is restarted on every incoming edit.
+     */
+    private final Timer commitTimer;
+
+    /**
+     * Flag controlled by the owning {@link EditorTab} to suppress event processing
+     * during programmatic text changes (e.g. font reloads, encryption results).
+     */
+    private boolean enabled = true;
+
+    public GroupingUndoableEditListener(UndoManager undoManager) {
+        if (undoManager == null) {
+            throw new IllegalArgumentException("undoManager cannot be null");
+        }
+        this.undoManager = undoManager;
+
+        // Single-shot timer: fires once after COMMIT_DELAY_MS and commits the current group.
+        commitTimer = new Timer(COMMIT_DELAY_MS, e -> commitCurrentGroup());
+        commitTimer.setRepeats(false);
+    }
+
+    /**
+     * Returns whether this listener is currently processing events.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables or disables event processing. While disabled, incoming edits are ignored,
+     * and any in-progress group is committed and discarded so that programmatic changes
+     * do not pollute the undo stack.
+     */
+    public void setEnabled(boolean enabled) {
+        if (!enabled) {
+            // Commit whatever we have now so programmatic changes start with a clean slate.
+            commitCurrentGroup();
+        }
+        this.enabled = enabled;
+    }
+
+    /**
+     * Forces any in-progress group to be committed immediately.
+     * Useful when the document is saved or the tab is reset.
+     */
+    public void flush() {
+        commitCurrentGroup();
+    }
+
+    // -------------------------------------------------------------------------
+    // UndoableEditListener
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void undoableEditHappened(UndoableEditEvent e) {
+        if (!enabled) {
+            return;
+        }
+
+        UndoableEdit edit = e.getEdit();
+
+        // Ignore style-change events – they are not meaningful for undo purposes
+        // and would otherwise clutter the undo stack during reloadUI() calls.
+        if (!edit.isSignificant()) {
+            return;
+        }
+
+        // Open a new group if we don't have one yet.
+        if (currentGroup == null) {
+            currentGroup = new CompoundEdit();
+        }
+
+        currentGroup.addEdit(edit);
+
+        // (Re)start the idle timer so that the group is committed only after
+        // the user has paused for at least COMMIT_DELAY_MS milliseconds.
+        commitTimer.restart();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    /**
+     * Closes the current {@link CompoundEdit} and hands it to the {@link UndoManager}.
+     * If there is no current group, this is a no-op.
+     */
+    private void commitCurrentGroup() {
+        commitTimer.stop();
+
+        if (currentGroup == null) {
+            return;
+        }
+
+        CompoundEdit toCommit = currentGroup;
+        currentGroup = null;
+
+        toCommit.end(); // marks the compound edit as finished
+
+        // Only add it to the manager if it actually contains something significant.
+        if (toCommit.isSignificant()) {
+            undoManager.addEdit(toCommit);
+        }
+    }
+}
+

--- a/src/main/java/ca/corbett/crypttext/ui/MenuManager.java
+++ b/src/main/java/ca/corbett/crypttext/ui/MenuManager.java
@@ -140,6 +140,10 @@ public class MenuManager {
     private void rebuildEditMenu() {
         editMenu.removeAll();
 
+        editMenu.add(new JMenuItem(AppConfig.getInstance().getUndoAction()));
+        editMenu.add(new JMenuItem(AppConfig.getInstance().getRedoAction()));
+        editMenu.addSeparator();
+
         // Add any items to this list from our extensions, if any:
         List<JMenuItem> extensionItems = CryptTextExtensionManager.getInstance().getMenuItems("Edit");
         if (!extensionItems.isEmpty()) {

--- a/src/main/java/ca/corbett/crypttext/ui/actions/RedoAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/RedoAction.java
@@ -1,7 +1,10 @@
 package ca.corbett.crypttext.ui.actions;
 
+import ca.corbett.crypttext.ui.EditorTab;
+import ca.corbett.crypttext.ui.MainWindow;
 import ca.corbett.extras.EnhancedAction;
 
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 
 /**
@@ -19,8 +22,8 @@ public class RedoAction extends EnhancedAction {
     public void actionPerformed(ActionEvent e) {
         // It's weird that our editor tab pane allows tabs that aren't EditorTab instances.
         // Let's just filter them out. Might add code later to enforce EditorTabs only.
-        var c = ca.corbett.crypttext.ui.MainWindow.getInstance().getEditorTabPane().getCurrentTab();
-        if (!(c instanceof ca.corbett.crypttext.ui.EditorTab editorTab)) {
+        Component c = MainWindow.getInstance().getEditorTabPane().getCurrentTab();
+        if (!(c instanceof EditorTab editorTab)) {
             return;
         }
 

--- a/src/main/java/ca/corbett/crypttext/ui/actions/RedoAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/RedoAction.java
@@ -1,0 +1,30 @@
+package ca.corbett.crypttext.ui.actions;
+
+import ca.corbett.extras.EnhancedAction;
+
+import java.awt.event.ActionEvent;
+
+/**
+ * An action that redoes the last undone edit in the current editor tab.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class RedoAction extends EnhancedAction {
+
+    public RedoAction() {
+        super("Redo");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // It's weird that our editor tab pane allows tabs that aren't EditorTab instances.
+        // Let's just filter them out. Might add code later to enforce EditorTabs only.
+        var c = ca.corbett.crypttext.ui.MainWindow.getInstance().getEditorTabPane().getCurrentTab();
+        if (!(c instanceof ca.corbett.crypttext.ui.EditorTab editorTab)) {
+            return;
+        }
+
+        // Now we can delegate to the tab itself:
+        editorTab.redo();
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/ui/actions/UndoAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/UndoAction.java
@@ -1,0 +1,33 @@
+package ca.corbett.crypttext.ui.actions;
+
+import ca.corbett.crypttext.ui.EditorTab;
+import ca.corbett.crypttext.ui.MainWindow;
+import ca.corbett.extras.EnhancedAction;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+
+/**
+ * An action that undoes the last edit in the current editor tab.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class UndoAction extends EnhancedAction {
+
+    public UndoAction() {
+        super("Undo");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // It's weird that our editor tab pane allows tabs that aren't EditorTab instances.
+        // Let's just filter them out. Might add code later to enforce EditorTabs only.
+        Component c = MainWindow.getInstance().getEditorTabPane().getCurrentTab();
+        if (!(c instanceof EditorTab editorTab)) {
+            return;
+        }
+
+        // Now we can delegate to the tab itself:
+        editorTab.undo();
+    }
+}

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.1 - [TODO release date here]
+  #52 - Undo support: make keystroke configurable + compound edits.
   #50 - Undo support: Ctrl+Z undoes the last edit in each editor tab.
   #48 - Clicking line number gutter selects line(s) in text pane.
 


### PR DESCRIPTION
This PR addresses issue #52 by enhancing the "undo" feature added on a previous commit:

- wired up keystroke handling to be consistent with the rest of the application
- added support for "redo" since we get it for free from UndoManager
- added menu items for undo/redo
- added support for compound operations! Now, rapid successive edits count as one edit for undo/redo purposes.
