### PR TITLE
Issue #56 add shortcuts for editor font size up and down

### DIFF
--- a/src/main/java/ca/corbett/crypttext/AppConfig.java
+++ b/src/main/java/ca/corbett/crypttext/AppConfig.java
@@ -7,6 +7,8 @@ import ca.corbett.crypttext.ui.actions.AboutAction;
 import ca.corbett.crypttext.ui.actions.CryptAction;
 import ca.corbett.crypttext.ui.actions.ExitAction;
 import ca.corbett.crypttext.ui.actions.ExtensionManagerAction;
+import ca.corbett.crypttext.ui.actions.FontSizeDownAction;
+import ca.corbett.crypttext.ui.actions.FontSizeUpAction;
 import ca.corbett.crypttext.ui.actions.ForgetPasswordAction;
 import ca.corbett.crypttext.ui.actions.LogConsoleAction;
 import ca.corbett.crypttext.ui.actions.NewTabAction;
@@ -91,6 +93,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private static final String KEY_SAVE_UNENCRYPTED = KEYSTROKE_PREFIX + "General.saveUnencrypted";
     private static final String KEY_UNDO = KEYSTROKE_PREFIX + "General.undo";
     private static final String KEY_REDO = KEYSTROKE_PREFIX + "General.redo";
+    private static final String KEY_FONT_SIZE_UP = KEYSTROKE_PREFIX + "General.fontSizeUp";
+    private static final String KEY_FONT_SIZE_DOWN = KEYSTROKE_PREFIX + "General.fontSizeDown";
     private static final String KEY_CRYPT = KEYSTROKE_PREFIX + "General.crypt";
     private static final String KEY_FORGET_PASSWORD = KEYSTROKE_PREFIX + "General.forgetPassword";
     private static final String KEY_PROPERTIES = KEYSTROKE_PREFIX + "General.properties";
@@ -134,6 +138,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private Action saveUnencryptedAction;
     private Action undoAction;
     private Action redoAction;
+    private Action fontSizeUpAction;
+    private Action fontSizeDownAction;
     private Action cryptAction;
     private Action forgetPasswordAction;
     private Action propertiesAction;
@@ -211,6 +217,14 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         return redoAction;
     }
 
+    public Action getFontSizeUpAction() {
+        return fontSizeUpAction;
+    }
+
+    public Action getFontSizeDownAction() {
+        return fontSizeDownAction;
+    }
+
     public Action getCryptAction() {
         return cryptAction;
     }
@@ -254,6 +268,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_SAVE_UNENCRYPTED));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_UNDO));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_REDO));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_UP));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_DOWN));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_CRYPT));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FORGET_PASSWORD));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_PROPERTIES));
@@ -351,6 +367,28 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
      */
     public Font getEditorFont() {
         return editorFontProp.getFont();
+    }
+
+    /**
+     * Returns the currently configured point size of the editor font.
+     */
+    public int getEditorFontSize() {
+        return editorFontProp.getFont().getSize();
+    }
+
+    /**
+     * Sets the editor font size to the given point size, while keeping the same font family and style.
+     * Triggers an immediate save to persist this change. There are no upper bounds checks,
+     * but the given point size must be greater than zero.
+     *
+     * @param pointSize The new font size in points (e.g. 14). Must be positive.
+     */
+    public void setEditorFontSize(int pointSize) {
+        if (pointSize <= 0) {
+            throw new IllegalArgumentException("Font size must be positive");
+        }
+        editorFontProp.setFont(getEditorFont().deriveFont((float)pointSize));
+        save(); // immediate save to persist this change
     }
 
     /**
@@ -476,6 +514,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         saveUnencryptedAction = new SaveUnencryptedAction();
         undoAction = new UndoAction();
         redoAction = new RedoAction();
+        fontSizeUpAction = new FontSizeUpAction();
+        fontSizeDownAction = new FontSizeDownAction();
         cryptAction = new CryptAction();
         forgetPasswordAction = new ForgetPasswordAction();
         propertiesAction = new PropertiesAction();
@@ -660,6 +700,14 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         props.add(new KeyStrokeProperty(KEY_REDO, "Redo:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+Y"),
                                         redoAction)
+                          .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_FONT_SIZE_UP, "Increase Font Size:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+Equals"), // VK_PLUS fails???
+                                        fontSizeUpAction)
+                          .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_FONT_SIZE_DOWN, "Decrease Font Size:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+Minus"),
+                                        fontSizeDownAction)
                           .setAllowBlank(true));
         props.add(new KeyStrokeProperty(KEY_CRYPT, "Encrypt/Decrypt:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+D"), // D for "decrypt/crypt" :)

--- a/src/main/java/ca/corbett/crypttext/ui/MenuManager.java
+++ b/src/main/java/ca/corbett/crypttext/ui/MenuManager.java
@@ -142,6 +142,8 @@ public class MenuManager {
 
         editMenu.add(new JMenuItem(AppConfig.getInstance().getUndoAction()));
         editMenu.add(new JMenuItem(AppConfig.getInstance().getRedoAction()));
+        editMenu.add(new JMenuItem(AppConfig.getInstance().getFontSizeUpAction()));
+        editMenu.add(new JMenuItem(AppConfig.getInstance().getFontSizeDownAction()));
         editMenu.addSeparator();
 
         // Add any items to this list from our extensions, if any:

--- a/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeDownAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeDownAction.java
@@ -28,7 +28,7 @@ public class FontSizeDownAction extends EnhancedAction {
         int currentSize = AppConfig.getInstance().getEditorFontSize();
         int newSize = currentSize - 2;
         if (newSize <= 0) {
-            log.warning("Cannot decrease editor font size below 2 points.");
+            log.warning("Cannot decrease editor font size to zero!");
             return; // don't allow non-positive font sizes
         }
         log.info("Decreasing editor font size from " + currentSize + " to " + newSize);

--- a/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeDownAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeDownAction.java
@@ -1,0 +1,38 @@
+package ca.corbett.crypttext.ui.actions;
+
+import ca.corbett.crypttext.AppConfig;
+import ca.corbett.extras.EnhancedAction;
+
+import java.awt.event.ActionEvent;
+import java.util.logging.Logger;
+
+/**
+ * A simple action to decrease the editor font size by 2 points,
+ * then trigger an immediate preferences save and UI reload.
+ * Changes will take effect immediately, and will persist across application restarts.
+ * There is a lower bound of 2 points, to prevent non-positive font sizes.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class FontSizeDownAction extends EnhancedAction {
+
+    private static final Logger log = Logger.getLogger(FontSizeDownAction.class.getName());
+
+    public FontSizeDownAction() {
+        super("Decrease editor font size");
+        setTooltip("Decrease the font size used in the editor by 2 points.");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        int currentSize = AppConfig.getInstance().getEditorFontSize();
+        int newSize = currentSize - 2;
+        if (newSize <= 0) {
+            log.warning("Cannot decrease editor font size below 2 points.");
+            return; // don't allow non-positive font sizes
+        }
+        log.info("Decreasing editor font size from " + currentSize + " to " + newSize);
+        AppConfig.getInstance().setEditorFontSize(newSize); // triggers an immediate preference save
+        UIReloadAction.getInstance().actionPerformed(null); // force a reload of the UI
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeUpAction.java
+++ b/src/main/java/ca/corbett/crypttext/ui/actions/FontSizeUpAction.java
@@ -1,0 +1,34 @@
+package ca.corbett.crypttext.ui.actions;
+
+import ca.corbett.crypttext.AppConfig;
+import ca.corbett.extras.EnhancedAction;
+
+import java.awt.event.ActionEvent;
+import java.util.logging.Logger;
+
+/**
+ * A simple action to increase the editor font size by 2 points,
+ * then trigger an immediate preferences save and UI reload.
+ * Changes will take effect immediately, and will persist across application restarts.
+ * There is no upper bounds checking! Don't go crazy with it.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class FontSizeUpAction extends EnhancedAction {
+
+    private static final Logger log = Logger.getLogger(FontSizeUpAction.class.getName());
+
+    public FontSizeUpAction() {
+        super("Increase editor font size");
+        setTooltip("Increase the font size used in the editor by 2 points.");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        int currentSize = AppConfig.getInstance().getEditorFontSize();
+        int newSize = currentSize + 2;
+        log.info("Increasing editor font size from " + currentSize + " to " + newSize);
+        AppConfig.getInstance().setEditorFontSize(newSize); // triggers an immediate preference save
+        UIReloadAction.getInstance().actionPerformed(null); // force a reload of the UI
+    }
+}

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -3,6 +3,7 @@ CryptText Release Notes
 
 Version 1.1 - [TODO release date here]
   #58 - Allow drag and drop from OS file manager to open file(s).
+  #56 - Add keyboard shortcuts for changing font size on the fly.
   #52 - Undo support: make keystroke configurable + compound edits.
   #50 - Undo support: Ctrl+Z undoes the last edit in each editor tab.
   #48 - Clicking line number gutter selects line(s) in text pane.


### PR DESCRIPTION
This PR addresses issue #56 by adding an easy way to increase or decrease the editor font size:

- created new keyboard shortcuts and wired them up with reasonable defaults
- added new menu items in the Edit menu
- when triggered, the associated action will immediately save the new value and force a UI reload

