### PR TITLE
Issue #62 - DirTree: more config options

### DIFF
--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/DirTreeExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/DirTreeExtension.java
@@ -21,6 +21,7 @@ import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.extras.properties.LabelProperty;
+import ca.corbett.extras.properties.ShortTextProperty;
 
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
@@ -30,6 +31,7 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +51,8 @@ public class DirTreeExtension extends CryptTextExtension implements UIReloadable
 
     private static final String INTRO_LABEL_PROP = "UI.DirTree.introLabel";
     private static final String SHOW_TREE_PROP = "UI.DirTree.showTree";
+    private static final String SHOW_HIDDEN_PROP = "UI.DirTree.showHidden";
+    private static final String FILE_FILTER_PROP = "UI.DirTree.fileFilter";
     private static final String WIDTH_PROP = "UI.DirTree.treeWidth";
     private static final String KEY_PROP = AppConfig.KEYSTROKE_PREFIX + "General.toggleKey";
 
@@ -74,8 +78,9 @@ public class DirTreeExtension extends CryptTextExtension implements UIReloadable
     public void onActivate() {
         dirTree = new DirTree(AppConfig.getInstance().getLastBrowseDirectory());
         dirTree.setName("DirTree"); // in case we get added to a JTabbedPane
-        dirTree.setShowFiles(true);
-        dirTree.setFileFilter(TextFileFilter.DEFAULT);
+        dirTree.setShowFiles(true); // this is subject to our FileFilter of course
+        dirTree.setShowHidden(isShowHiddenFiles());
+        dirTree.setFileFilter(getFileFilter());
         dirTree.addDirTreeListener(treeListener);
         setConfiguredTreeWidth(); // may have changed since we were last activated
         LookAndFeelManager.addChangeListener(lafChangeListener);
@@ -103,11 +108,17 @@ public class DirTreeExtension extends CryptTextExtension implements UIReloadable
                                     "<html>This extension adds an optional directory tree" +
                                             "<br>to the left of the editor for quick file navigation.</html>"));
         props.add(new BooleanProperty(SHOW_TREE_PROP, "Show directory tree", true));
+        props.add(new BooleanProperty(SHOW_HIDDEN_PROP, "Show hidden files and directories", false));
         props.add(new KeyStrokeProperty(KEY_PROP, "Show/hide DirTree",
                                         KeyStrokeManager.parseKeyStroke("F4"),
                                         new ToggleTreeAction())
                           .setAllowBlank(true));
         props.add(new IntegerProperty(WIDTH_PROP, "Tree width:", DEFAULT_TREE_WIDTH, 80, 1200, 10));
+        props.add(new ShortTextProperty(FILE_FILTER_PROP, "File filter:", "txt", 15)
+                          .setAllowBlank(true)
+                          .setHelpText("<html>A comma-separated list of file extensions, without dots<br>" +
+                                               "For example: <i>txt, md, html</i>" +
+                                               "<br><br>A blank list will show all files.</html>"));
 
         return props;
     }
@@ -128,7 +139,10 @@ public class DirTreeExtension extends CryptTextExtension implements UIReloadable
 
     @Override
     public void reloadUI() {
+        // Adjust tree options based on current config values:
         setConfiguredTreeWidth();
+        dirTree.setShowHidden(isShowHiddenFiles());
+        dirTree.setFileFilter(getFileFilter());
 
         // Force a redraw of the parent container:
         Container container = dirTree.getParent();
@@ -160,6 +174,63 @@ public class DirTreeExtension extends CryptTextExtension implements UIReloadable
             return intProp.getValue();
         }
         return DEFAULT_TREE_WIDTH;
+    }
+
+    /**
+     * Looks up the current value of our "show hidden" config prop and returns it, or false if not found.
+     */
+    private boolean isShowHiddenFiles() {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(SHOW_HIDDEN_PROP);
+        if (prop instanceof BooleanProperty boolProp) {
+            return boolProp.getValue();
+        }
+        return false;
+    }
+
+    /**
+     * Returns the raw string value of our file filter config prop, or an empty string if not found.
+     */
+    private String getFileFilterAsString() {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(FILE_FILTER_PROP);
+        if (prop instanceof ShortTextProperty textProp) {
+            return textProp.getValue();
+        }
+        return "";
+    }
+
+    /**
+     * Gets our configured file filter as a FileFilter object.
+     * If the config prop is blank or invalid, returns null to indicate no filter.
+     */
+    private FileFilter getFileFilter() {
+        String filterStr = getFileFilterAsString();
+        if (filterStr.isBlank()) {
+            return null; // no filter
+        }
+        else {
+            return new TextFileFilter(stringToList(filterStr));
+        }
+    }
+
+    /**
+     * Internal utility to convert the given String into a List of Strings, assuming
+     * that the String is comma-separated. For example, "txt, md, java" would be
+     * converted to a List containing "txt", "md", and "java".
+     * Whitespace before and after commas are trimmed, and empty items are ignored.
+     * So "txt, , md, java, " would be treated the same as "txt,md,java".
+     */
+    private List<String> stringToList(String s) {
+        if (s == null || s.isBlank()) {
+            return List.of();
+        }
+        List<String> list = new ArrayList<>();
+        for (String item : s.split(",")) {
+            String trimmed = item.trim();
+            if (!trimmed.isEmpty()) {
+                list.add(trimmed);
+            }
+        }
+        return list;
     }
 
     /**

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.1 - [TODO release date here]
+  #62 - DirTree: more config options.
   #58 - Allow drag and drop from OS file manager to open file(s).
   #56 - Add keyboard shortcuts for changing font size on the fly.
   #54 - DirTree: allow configurable width.


### PR DESCRIPTION
This PR addresses issue #62 by adding additional configuration options for the DirTree component:

- explicit option to show/hide hidden files. This was already accessible via the right-click popup menu on the DirTree, but we now have an explicit option for it in application preferences. The DirTree's popup menu will keep itself in sync with this new option.
- file filter. Previously, we hard-coded this to only show text files. Now, the user can enter a comma-separated list of extensions, or blank out the field to mean "show everything". The DirTree already intelligently checks to ensure that a double-clicked file is actually a text file before loading it, so there's no risk of the user choosing a file extension that makes no sense (like `jpg`).
