### PR TITLE
Issue #57 - EditorTab: scroll to top when opening tabs

### DIFF
--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -116,6 +116,7 @@ public class EditorTab extends JPanel implements UIReloadable {
         add(wrapperPanel, BorderLayout.CENTER);
         this.diskContents = diskContents;
         textPane.setText(this.diskContents.getText()); // initial value
+        textPane.setCaretPosition(0); // move caret to beginning of whatever text we just loaded.
         this.cryptMetadata = generateCryptMetadata();
         textPane.getDocument().addDocumentListener(new DocListener());
         undoManager = new UndoManager();
@@ -199,6 +200,15 @@ public class EditorTab extends JPanel implements UIReloadable {
         if (undoManager.canRedo()) {
             undoManager.redo();
         }
+    }
+
+    /**
+     * Invoke this to try to set the keyboard focus to the text pane in this editor tab.
+     * This is not guaranteed to work, just because of the way the focus system
+     * works in general, but we'll give it a shot.
+     */
+    public void requestFocusInTextPane() {
+        textPane.requestFocusInWindow();
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -208,7 +208,8 @@ public class EditorTab extends JPanel implements UIReloadable {
      * works in general, but we'll give it a shot.
      */
     public void requestFocusInTextPane() {
-        textPane.requestFocusInWindow();
+        ownerPane.setSelectedComponent(this); // first, make sure we're the active tab, otherwise focus won't come to us
+        SwingUtilities.invokeLater(textPane::requestFocusInWindow);
     }
 
     /**

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
@@ -95,6 +95,7 @@ public class EditorTabPane extends JTabbedPane {
             if (tab instanceof EditorTab editorTab) {
                 if (editorTab.getDiskContents().isSameSourceFile(text)) {
                     setSelectedIndex(i);
+                    editorTab.requestFocusInTextPane();
                     return;
                 }
             }
@@ -105,6 +106,7 @@ public class EditorTabPane extends JTabbedPane {
         editorTabs.add(editorTab);
         addTab(title, editorTab.getIcon(), editorTab);
         setTabComponentAt(getTabCount() - 1, editorTab.getTabHeader());
+        editorTab.requestFocusInTextPane();
 
         // If this isn't a scratch file, add it to the "recent files" list:
         if (!editorTab.isScratchFile()) {

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -4,6 +4,7 @@ CryptText Release Notes
 Version 1.1 - [TODO release date here]
   #62 - DirTree: more config options.
   #58 - Allow drag and drop from OS file manager to open file(s).
+  #57 - EditorTab: scroll to top when opening tabs.
   #56 - Add keyboard shortcuts for changing font size on the fly.
   #54 - DirTree: allow configurable width.
   #52 - Undo support: make keystroke configurable + compound edits.


### PR DESCRIPTION
This PR addresses issue #57 by forcing the caret to the start of newly-opened files, and requesting focus in the JTextPane when opening a new tab.

Dev note: requesting focus is hit-and-miss. The best we can do is request it, but we're not guaranteed to get it. From testing, I find it works when going through the JFileChooser, but it does NOT work when double-clicking items in the DirTree, probably because double-clicking the tree gives focus explicitly to the tree.