### PR TITLE
Issue #65 better cursor options

### DIFF
--- a/src/main/java/ca/corbett/crypttext/AppConfig.java
+++ b/src/main/java/ca/corbett/crypttext/AppConfig.java
@@ -26,6 +26,7 @@ import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.ColorProperty;
+import ca.corbett.extras.properties.ComboProperty;
 import ca.corbett.extras.properties.DirectoryProperty;
 import ca.corbett.extras.properties.EnumProperty;
 import ca.corbett.extras.properties.FontProperty;
@@ -119,6 +120,8 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     private BooleanProperty showLineNumbersProp;
     private FontProperty editorFontProp;
     private FontProperty gutterFontProp;
+    private BooleanProperty useBlockCursorProp;
+    private ComboProperty<String> blinkRateProp;
     private BooleanProperty overrideLafProp;
     private EnumProperty<ColorTheme> editorThemeProp;
     private ColorProperty editorBackgroundColorProp;
@@ -399,6 +402,42 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
     }
 
     /**
+     * Reports whether the user wants to use our custom "block" cursor,
+     * or stick with the boring default one.
+     */
+    public boolean isUseBlockCursor() {
+        return useBlockCursorProp.getValue();
+    }
+
+    /**
+     * Reports the rate, in milliseconds, at which the cursor is
+     * configured to blink. A value of zero means "don't blink".
+     * This option applies to both the standard cursor and
+     * also our own custom BlockCursor.
+     */
+    public int getCursorBlinkRate() {
+        return switch (blinkRateProp.getSelectedIndex()) {
+            case 0 -> 0; // don't blink
+            case 1 -> 250; // fast
+            case 3 -> 1000; // slow
+            default -> 500; // normal
+        };
+    }
+
+    /**
+     * Reports whether the user has opted to override the Look and Feel and set
+     * custom colors. Generally, you don't need to worry about this! When you invoke
+     * the various getXColor() methods, they will automatically check this property
+     * and return the appropriate color based on the current Look and Feel or the
+     * user-selected custom color. But, if you need to know whether the
+     * current colors are coming from the Look and Feel or from user overrides,
+     * you can check this property.
+     */
+    public boolean isOverrideLookAndFeel() {
+        return overrideLafProp.getValue();
+    }
+
+    /**
      * Returns the configured editor background color.
      * This will come from the current Look and Feel if we are not set to override it.
      * Otherwise, this is the user-selected background color.
@@ -555,6 +594,17 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
                                                   "Show line numbers in editor",
                                                   true);
         props.add(showLineNumbersProp);
+
+        useBlockCursorProp = new BooleanProperty("UI.Editor.useBlockCursor",
+                                                 "Use block cursor in editor",
+                                                 false);
+        props.add(useBlockCursorProp);
+
+        List<String> options = List.of("Don't blink", "Fast", "Normal", "Slow");
+        blinkRateProp = new ComboProperty<>("UI.Editor.cursorBlinkRate",
+                                            "Blink rate:",
+                                            options, 0, false);
+        props.add(blinkRateProp);
 
         overrideLafProp = new BooleanProperty("UI.Editor.overrideLaF",
                                               "Override Look and Feel with custom editor colors",

--- a/src/main/java/ca/corbett/crypttext/AppConfig.java
+++ b/src/main/java/ca/corbett/crypttext/AppConfig.java
@@ -603,7 +603,7 @@ public class AppConfig extends AppProperties<CryptTextExtension> {
         List<String> options = List.of("Don't blink", "Fast", "Normal", "Slow");
         blinkRateProp = new ComboProperty<>("UI.Editor.cursorBlinkRate",
                                             "Blink rate:",
-                                            options, 0, false);
+                                            options, 2, false);
         props.add(blinkRateProp);
 
         overrideLafProp = new BooleanProperty("UI.Editor.overrideLaF",

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -15,15 +15,21 @@ import java.awt.Rectangle;
  */
 public class BlockCursor extends DefaultCaret {
 
+    private static final int ALPHA = 192; // 75% opacity, currently not configurable
     private final Timer blinkTimer;
+    private final Color cursorColor;
 
     /**
      * Creates a new BlockCursor with the specified blink rate in milliseconds.
      * A value of zero or less means "don't blink".
      *
      * @param blinkRate The blink rate in milliseconds, or zero/negative for no blinking.
+     * @param color The desired cursor color
      */
-    public BlockCursor(int blinkRate) {
+    public BlockCursor(int blinkRate, Color color) {
+        // We want the block cursor to be 75% opaque:
+        cursorColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), ALPHA);
+
         // The parent class's timer has strange behavior where the blink rate slows
         // down noticeably when no mouse or keyboard activity is happening in the text pane.
         // We can try to work around this by creating our own timer and bypassing
@@ -85,13 +91,9 @@ public class BlockCursor extends DefaultCaret {
     public void paint(Graphics g) {
         if (isVisible() && getComponent() != null) {
             try {
-                // We want the block cursor to be 75% opaque:
-                Color cursorColor = getComponent().getCaretColor();
-                Color newColor = new Color(cursorColor.getRed(), cursorColor.getGreen(), cursorColor.getBlue(), 192);
-
                 // Get the target rectangle and set our color:
                 Rectangle r = getComponent().getUI().modelToView(getComponent(), getDot());
-                g.setColor(newColor);
+                g.setColor(cursorColor);
 
                 // In my testing, I find that r.width is always 0, and I don't know why.
                 // So, let's set something reasonable instead:

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -7,7 +7,6 @@ import javax.swing.text.JTextComponent;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Rectangle;
-import java.util.logging.Logger;
 
 /**
  * A custom "block" cursor, for that old-school terminal feel.
@@ -16,10 +15,7 @@ import java.util.logging.Logger;
  */
 public class BlockCursor extends DefaultCaret {
 
-    private static final Logger log = Logger.getLogger(BlockCursor.class.getName());
-
     private final Timer blinkTimer;
-    private final int blinkRate;
 
     /**
      * Creates a new BlockCursor with the specified blink rate in milliseconds.
@@ -28,34 +24,38 @@ public class BlockCursor extends DefaultCaret {
      * @param blinkRate The blink rate in milliseconds, or zero/negative for no blinking.
      */
     public BlockCursor(int blinkRate) {
-        this.blinkRate = blinkRate;
-
         // The parent class's timer has strange behavior where the blink rate slows
         // down noticeably when no mouse or keyboard activity is happening in the text pane.
         // We can try to work around this by creating our own timer and bypassing
         // the RepaintManager's timer coalescing behavior, but in my testing,
         // this does not do much to fix the problem. It remains unsolved for now.
         setBlinkRate(0); // disable parent class's timer... we'll make our own
-        blinkTimer = new Timer(blinkRate, e -> {
-            setVisible(!isVisible());
-            if (getComponent() != null) {
-                getComponent().paintImmediately(x, y, width, height);
-            }
-        });
-        blinkTimer.setCoalesce(false); // don't skip missed ticks
+
+        if (blinkRate > 0) {
+            blinkTimer = new Timer(blinkRate, e -> {
+                if (getComponent() != null && getComponent().hasFocus()) {
+                    setVisible(!isVisible());
+                    getComponent().paintImmediately(x, y, width, height);
+                }
+            });
+            blinkTimer.setCoalesce(false); // don't skip missed ticks
+        }
+        else {
+            blinkTimer = null; // no timer needed if we're not blinking
+        }
     }
 
     @Override
     public void install(JTextComponent c) {
         super.install(c);
-        if (blinkRate > 0) { // 0 means "don't blink"
+        if (blinkTimer != null) {
             blinkTimer.start();
         }
     }
 
     @Override
     public void deinstall(JTextComponent c) {
-        if (blinkRate > 0) { // 0 means "don't blink", so our timer was never started
+        if (blinkTimer != null) {
             blinkTimer.stop();
         }
         super.deinstall(c);

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -66,7 +66,7 @@ public class BlockCursor extends DefaultCaret {
      */
     @Override
     public void damage(Rectangle r) {
-        if (r == null) {
+        if (r == null && getComponent() == null) {
             return;
         }
         x = r.x;
@@ -83,7 +83,7 @@ public class BlockCursor extends DefaultCaret {
      */
     @Override
     public void paint(Graphics g) {
-        if (isVisible()) {
+        if (isVisible() && getComponent() != null) {
             try {
                 // We want the block cursor to be 75% opaque:
                 Color cursorColor = getComponent().getCaretColor();

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -1,0 +1,106 @@
+package ca.corbett.crypttext.ui;
+
+import javax.swing.Timer;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.JTextComponent;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.util.logging.Logger;
+
+/**
+ * A custom "block" cursor, for that old-school terminal feel.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class BlockCursor extends DefaultCaret {
+
+    private static final Logger log = Logger.getLogger(BlockCursor.class.getName());
+
+    private final Timer blinkTimer;
+    private final int blinkRate;
+
+    /**
+     * Creates a new BlockCursor with the specified blink rate in milliseconds.
+     * A value of zero or less means "don't blink".
+     *
+     * @param blinkRate The blink rate in milliseconds, or zero/negative for no blinking.
+     */
+    public BlockCursor(int blinkRate) {
+        this.blinkRate = blinkRate;
+
+        // The parent class's timer has strange behavior where the blink rate slows
+        // down noticeably when no mouse or keyboard activity is happening in the text pane.
+        // We can try to work around this by creating our own timer and bypassing
+        // the RepaintManager's timer coalescing behavior, but in my testing,
+        // this does not do much to fix the problem. It remains unsolved for now.
+        setBlinkRate(0); // disable parent class's timer... we'll make our own
+        blinkTimer = new Timer(blinkRate, e -> {
+            setVisible(!isVisible());
+            if (getComponent() != null) {
+                getComponent().paintImmediately(x, y, width, height);
+            }
+        });
+        blinkTimer.setCoalesce(false); // don't skip missed ticks
+    }
+
+    @Override
+    public void install(JTextComponent c) {
+        super.install(c);
+        if (blinkRate > 0) { // 0 means "don't blink"
+            blinkTimer.start();
+        }
+    }
+
+    @Override
+    public void deinstall(JTextComponent c) {
+        if (blinkRate > 0) { // 0 means "don't blink", so our timer was never started
+            blinkTimer.stop();
+        }
+        super.deinstall(c);
+    }
+
+    /**
+     * Adjusts the damaged area to cover the full character width.
+     */
+    @Override
+    public void damage(Rectangle r) {
+        if (r == null) {
+            return;
+        }
+        x = r.x;
+        y = r.y;
+        width = getComponent().getFontMetrics(getComponent().getFont()).charWidth('m');
+        height = r.height;
+        repaint(); // calls getComponent().repaint(x, y, width, height)
+    }
+
+    /**
+     * Calculates the width based on character metrics and fills
+     * the given rectangle to render the block cursor.
+     * If the dot position is invalid, it fails silently.
+     */
+    @Override
+    public void paint(Graphics g) {
+        if (isVisible()) {
+            try {
+                // We want the block cursor to be 75% opaque:
+                Color cursorColor = getComponent().getCaretColor();
+                Color newColor = new Color(cursorColor.getRed(), cursorColor.getGreen(), cursorColor.getBlue(), 192);
+
+                // Get the target rectangle and set our color:
+                Rectangle r = getComponent().getUI().modelToView(getComponent(), getDot());
+                g.setColor(newColor);
+
+                // In my testing, I find that r.width is always 0, and I don't know why.
+                // So, let's set something reasonable instead:
+                int width = getComponent().getFontMetrics(getComponent().getFont()).charWidth('m');
+                g.fillRect(r.x, r.y, width, r.height);
+            }
+            catch (BadLocationException e) {
+                // can't render cursor
+            }
+        }
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -22,6 +22,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.CaretEvent;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.DefaultCaret;
 import javax.swing.undo.UndoManager;
 import java.awt.BorderLayout;
 import java.io.File;
@@ -573,6 +574,8 @@ public class EditorTab extends JPanel implements UIReloadable {
      */
     @Override
     public void reloadUI() {
+        final AppConfig appConfig = AppConfig.getInstance();
+
         // Weirdly, some of these calls will trigger a change event.
         // Example: textPane.setFont() schedules a changedUpdate via SwingUtilities.invokeLater
         // deep inside DefaultStyledDocument.styleChanged. That means the changedUpdate fires
@@ -581,14 +584,23 @@ public class EditorTab extends JPanel implements UIReloadable {
         // the style-change event and will therefore run after eventsEnabled has been checked.
         eventsEnabled = false;
         undoableEditListener.setEnabled(false);
-        undoManager.setLimit(AppConfig.getInstance().getUndoLimit());
+        undoManager.setLimit(appConfig.getUndoLimit());
         try {
-            scrollPane.setRowHeaderView(AppConfig.getInstance().isShowLineNumbers() ? gutter : null);
-            textPane.setFont(AppConfig.getInstance().getEditorFont());
-            gutter.setLineNumberFont(AppConfig.getInstance().getGutterFont());
+            scrollPane.setRowHeaderView(appConfig.isShowLineNumbers() ? gutter : null);
+            textPane.setFont(appConfig.getEditorFont());
+            gutter.setLineNumberFont(appConfig.getGutterFont());
             gutter.updateColors(); // tell our gutter to update its colors based on the current theme
-            textPane.setBackground(AppConfig.getInstance().getEditorBackgroundColor());
-            textPane.setForeground(AppConfig.getInstance().getEditorForegroundColor());
+            textPane.setBackground(appConfig.getEditorBackgroundColor());
+            textPane.setForeground(appConfig.getEditorForegroundColor());
+            textPane.setCaretColor(appConfig.getEditorForegroundColor());
+            if (appConfig.isOverrideLookAndFeel() && appConfig.isUseBlockCursor()) {
+                textPane.setCaret(new BlockCursor(appConfig.getCursorBlinkRate()));
+            }
+            else {
+                // boring cursor activated!
+                textPane.setCaret(new DefaultCaret());
+                textPane.getCaret().setBlinkRate(appConfig.getCursorBlinkRate());
+            }
             repaint();
         }
         finally {

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -593,7 +593,7 @@ public class EditorTab extends JPanel implements UIReloadable {
             textPane.setBackground(appConfig.getEditorBackgroundColor());
             textPane.setForeground(appConfig.getEditorForegroundColor());
             textPane.setCaretColor(appConfig.getEditorForegroundColor());
-            if (appConfig.isOverrideLookAndFeel() && appConfig.isUseBlockCursor()) {
+            if (appConfig.isUseBlockCursor()) {
                 textPane.setCaret(new BlockCursor(appConfig.getCursorBlinkRate()));
             }
             else {

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -593,6 +593,12 @@ public class EditorTab extends JPanel implements UIReloadable {
             textPane.setBackground(appConfig.getEditorBackgroundColor());
             textPane.setForeground(appConfig.getEditorForegroundColor());
             textPane.setCaretColor(appConfig.getEditorForegroundColor());
+
+            // Note these because swapping out the caret might reset them:
+            int savedDot = textPane.getCaret().getDot();
+            int savedMark = textPane.getCaret().getMark();
+
+            // Swap out the caret as needed:
             if (appConfig.isUseBlockCursor()) {
                 textPane.setCaret(new BlockCursor(appConfig.getCursorBlinkRate()));
             }
@@ -601,6 +607,11 @@ public class EditorTab extends JPanel implements UIReloadable {
                 textPane.setCaret(new DefaultCaret());
                 textPane.getCaret().setBlinkRate(appConfig.getCursorBlinkRate());
             }
+
+            // Restore the caret position after swapping out the caret, otherwise it will jump to the beginning:
+            textPane.getCaret().setDot(savedMark);
+            textPane.getCaret().moveDot(savedDot);
+
             repaint();
         }
         finally {

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -25,6 +25,7 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.DefaultCaret;
 import javax.swing.undo.UndoManager;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -590,9 +591,10 @@ public class EditorTab extends JPanel implements UIReloadable {
             textPane.setFont(appConfig.getEditorFont());
             gutter.setLineNumberFont(appConfig.getGutterFont());
             gutter.updateColors(); // tell our gutter to update its colors based on the current theme
+            Color fg = appConfig.getEditorForegroundColor();
             textPane.setBackground(appConfig.getEditorBackgroundColor());
-            textPane.setForeground(appConfig.getEditorForegroundColor());
-            textPane.setCaretColor(appConfig.getEditorForegroundColor());
+            textPane.setForeground(fg);
+            textPane.setCaretColor(fg);
 
             // Note these because swapping out the caret might reset them:
             int savedDot = textPane.getCaret().getDot();
@@ -600,7 +602,7 @@ public class EditorTab extends JPanel implements UIReloadable {
 
             // Swap out the caret as needed:
             if (appConfig.isUseBlockCursor()) {
-                textPane.setCaret(new BlockCursor(appConfig.getCursorBlinkRate()));
+                textPane.setCaret(new BlockCursor(appConfig.getCursorBlinkRate(), fg));
             }
             else {
                 // boring cursor activated!

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.1 - [TODO release date here]
+  #65 - Better cursor handling with custom themes.
   #62 - DirTree: more config options.
   #58 - Allow drag and drop from OS file manager to open file(s).
   #57 - EditorTab: scroll to top when opening tabs.


### PR DESCRIPTION
This PR addresses issue #65 by updating the caret color in our text panes when the user has opted to override the Look and Feel default colors. This allows the cursor to be visible, even when the custom background color changes.

Also added a custom `BlockCursor` option with configurable blink rate, because it looks cool and because I was bored with the default caret.