### PR TITLE
Issue #55 fullscreen mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,465 @@
+# CryptText Codebase Guide for AI Coding Assistants
+
+This guide provides comprehensive information about the CryptText project structure, architecture, and conventions to help AI assistants work efficiently with the codebase.
+
+## 1. Project Overview
+
+**CryptText** is a user-friendly Java Swing text editor with built-in encryption capabilities. Users can encrypt/decrypt text files using passwords without needing cryptographic knowledge. The application is built on the `swing-extras` framework and features an extensible plugin architecture.
+
+- **Purpose**: Simple encryption/decryption text editor with extensibility
+- **Main Features**:
+  - Text file editing with line numbers and customizable fonts
+  - Password-protected encryption/decryption (AES-GCM via Bouncy Castle)
+  - Tab-based multi-file editing
+  - Customizable Look & Feel and color themes
+  - Keyboard shortcut customization
+  - Built-in extensions: StatusBar and DirTree
+  - Extension system for adding features
+  - Recent files list
+  - Single-instance mode option
+  - Encryption metadata tracking
+
+## 2. Project Structure
+
+```
+crypttext/
+├── pom.xml                          # Maven configuration
+├── README.md                        # User documentation
+├── LICENSE                          # MIT License
+├── .editorconfig                    # Editor configuration
+├── installer.props                  # Installer properties
+├── src/
+│   ├── main/java/ca/corbett/crypttext/
+│   │   ├── Main.java            # Application entry point
+│   │   ├── Version.java         # Version and directory info
+│   │   ├── AppConfig.java       # Centralized configuration manager
+│   │   ├── RecentFilesManager.java
+│   │   ├── CryptTextResourceLoader.java
+│   │   ├── DecryptionFailedException.java
+│   │   ├── VetoException.java
+│   │   ├── crypt/               # Encryption/decryption logic
+│   │   │   ├── CryptUtil.java
+│   │   │   ├── CryptMetadata.java
+│   │   │   ├── DefaultCryptMetadata.java
+│   │   │   └── EncryptedText.java
+│   │   ├── text/                # Text model and management
+│   │   │   ├── Text.java
+│   │   │   ├── TextManager.java
+│   │   │   ├── TextChangedListener.java
+│   │   │   ├── TextLoadedListener.java
+│   │   │   ├── TextSavedListener.java
+│   │   │   ├── TextWillLoadListener.java
+│   │   │   └── TextWillSaveListener.java
+│   │   ├── ui/                  # GUI components
+│   │   │   ├── MainWindow.java
+│   │   │   ├── EditorTab.java
+│   │   │   ├── EditorTabPane.java
+│   │   │   ├── EditorTabHeader.java
+│   │   │   ├── LineNumberGutter.java
+│   │   │   ├── MenuManager.java
+│   │   │   ├── ColorTheme.java
+│   │   │   ├── TabStateManager.java
+│   │   │   ├── DefaultTabStateManager.java
+│   │   │   ├── UIReloadable.java
+│   │   │   ├── TextFileFilter.java
+│   │   │   └── actions/         # UI action implementations
+│   │   │       ├── AboutAction.java
+│   │   │       ├── CryptAction.java
+│   │   │       ├── ExitAction.java
+│   │   │       ├── ExtensionManagerAction.java
+│   │   │       ├── ForgetPasswordAction.java
+│   │   │       ├── LogConsoleAction.java
+│   │   │       ├── NewTabAction.java
+│   │   │       ├── OpenFileAction.java
+│   │   │       ├── PropertiesAction.java
+│   │   │       ├── SaveAction.java
+│   │   │       ├── SaveAsAction.java
+│   │   │       ├── SaveUnencryptedAction.java
+│   │   │       └── UIReloadAction.java
+│   │   └── extensions/          # Extension system
+│   │       ├── CryptTextExtension.java
+│   │       ├── CryptTextExtensionManager.java
+│   │       ├── ExtraComponentPosition.java
+│   │       └── builtin/
+│   │           ├── DirTreeExtension.java
+│   │           ├── StatusBarExtension.java
+│   │           └── TestExtension.java
+│   ├── main/resources/ca/corbett/crypttext/
+│   │   ├── logging.properties
+│   │   ├── file_header.txt
+│   │   ├── ReleaseNotes.txt
+│   │   ├── images/
+│   │   └── screenshots/
+│   └── test/java/ca/corbett/crypttext/
+│       ├── RecentFilesManagerTest.java
+│       ├── crypt/CryptUtilTest.java
+│       └── text/TextManagerTest.java
+```
+
+## 3. Build System
+
+**Build Tool**: Maven 3.x  
+**Java Version**: 17+
+
+### Key Build Commands
+```bash
+mvn clean package          # Build the project
+mvn test                   # Run all tests
+mvn test -Dtest=CryptUtilTest  # Run specific test
+```
+
+### Build Configuration
+- **Main Class**: `ca.corbett.crypttext.Main`
+- **JAR Assembly**: Executable jar with lib/ classpath
+- **Plugins**: maven-dependency-plugin, maven-surefire-plugin (JUnit 5), maven-jar-plugin
+
+## 4. Technology Stack
+
+### Core Dependencies
+- **Java 17** - Language and runtime
+- **Swing** - GUI framework (bundled with Java)
+- **swing-extras 2.8.0** - Custom Swing components and utilities
+- **Bouncy Castle (bcprov-jdk18on 1.83)** - Cryptography provider
+
+### Testing Dependencies
+- **JUnit 5 (junit-jupiter 5.12.1)**
+- **Mockito 5.14.2**
+
+### Encryption
+- **Algorithm**: AES-256 in GCM mode (authenticated encryption)
+- **Key Derivation**: Argon2 (memory-hard password hashing)
+- **Encoding**: Base64 (for file wrapper)
+
+## 5. Key Source Packages
+
+### ca.corbett.crypttext.crypt
+Handles cryptographic operations:
+- **CryptUtil**: Main encryption/decryption API
+  - `encrypt(password, plaintext)` / `decrypt(password, ciphertext)`
+  - `encryptAndWrap()` / `decryptAndUnwrap()`
+  - `isCryptTextWrapped()` - Detects encrypted files
+- **CryptMetadata**: Abstract base for encryption metadata (extensible)
+- **DefaultCryptMetadata**: Default implementation
+- **EncryptedText**: Data class for encrypted content
+
+### ca.corbett.crypttext.text
+Manages text loading/saving lifecycle with listeners:
+- **Text**: Immutable model object (text + source file)
+- **TextManager**: Controller for text operations, file I/O, listener dispatch
+- **Listeners**: TextWillLoadListener, TextLoadedListener, TextWillSaveListener, TextSavedListener, TextChangedListener
+
+### ca.corbett.crypttext.ui
+GUI components and event handling:
+- **MainWindow**: Main application frame (singleton)
+- **EditorTab**: Individual editor tab (JPanel + JTextPane)
+- **EditorTabPane**: Container for editor tabs
+- **MenuManager**: Constructs main menu bar
+- **LineNumberGutter**: Line number display
+- **ColorTheme**: Editor color scheme definition
+- **TabStateManager**: Persistence of open tabs (extensible interface)
+- **actions/**: UI action classes (each action = menu command)
+
+### ca.corbett.crypttext.extensions
+Plugin architecture:
+- **CryptTextExtension**: Abstract base class for extensions
+  - Hooks: getTopLevelMenus(), getMenuItems(), fileWillLoad(), fileWillSave()
+  - Access to MainWindow methods for tab manipulation
+- **CryptTextExtensionManager**: Singleton manager for extension lifecycle
+- **ExtraComponentPosition**: Enum for positioning extra UI components
+
+### ca.corbett.crypttext (Core)
+- **Main**: Entry point, initialization, single-instance management (port 54551)
+- **Version**: Version info, directory paths (INSTALL_DIR, SETTINGS_DIR, EXTENSIONS_DIR)
+- **AppConfig**: Centralized properties management (singleton)
+  - Extends swing-extras AppProperties
+  - Manages user settings, keyboard shortcuts, UI actions
+  - Integrates with CryptTextExtensionManager
+- **RecentFilesManager**: Recently-opened files list
+- **DecryptionFailedException**: Custom exception for decryption failures
+- **VetoException**: Extension veto signaling mechanism
+
+## 6. Main Classes and Responsibilities
+
+### Singleton Managers
+| Class | Responsibility |
+|-------|-----------------|
+| **MainWindow** | Main application frame, coordinates UI, file I/O |
+| **AppConfig** | All user settings, keystroke bindings, action creation |
+| **TextManager** | Text loading/saving, listener dispatch, scratch directory |
+| **CryptTextExtensionManager** | Extension lifecycle, hook invocation |
+| **RecentFilesManager** | Recent files list persistence |
+
+### UI Components
+| Class | Responsibility |
+|-------|-----------------|
+| **EditorTab** | Single editor tab with text pane, dirty tracking |
+| **EditorTabPane** | Container for editor tabs |
+| **MenuManager** | Main menu bar construction |
+| **LineNumberGutter** | Line numbers display |
+| **ColorTheme** | Editor color scheme |
+
+### Model Classes
+| Class | Responsibility |
+|-------|-----------------|
+| **Text** | Immutable text + source file pair |
+| **CryptMetadata** | Encryption metadata (abstract, extensible) |
+| **EncryptedText** | Encrypted content wrapper |
+
+## 7. Testing Conventions
+
+### Framework
+- **JUnit 5** (org.junit.jupiter)
+- **Mockito 5.14.2** for mocking
+- **Maven Surefire Plugin** for test execution
+
+### Test Location & Naming
+Tests follow Maven standard:
+```
+src/test/java/ca/corbett/crypttext/
+├── RecentFilesManagerTest.java
+├── crypt/CryptUtilTest.java
+└── text/TextManagerTest.java
+```
+
+### Test Method Style
+- **Naming**: `methodName_condition_expectedOutcome()`
+- **Example**: `encrypt_withValidDataAndPassword_shouldSucceed()`
+- **Pattern**: Given-When-Then structure
+
+```java
+@Test
+void testExample() {
+    // GIVEN setup
+    String password = "test";
+    
+    // WHEN action
+    byte[] result = CryptUtil.encrypt(password, data);
+    
+    // THEN verify
+    assertNotNull(result);
+}
+```
+
+### Current Tests
+1. **CryptUtilTest** - Encryption/decryption edge cases
+2. **TextManagerTest** - Text loading/saving lifecycle
+3. **RecentFilesManagerTest** - Recent files persistence
+
+## 8. Extension System
+
+### How It Works
+Extensions are loaded from `~/.CryptText/extensions/` directory. CryptTextExtensionManager discovers jar files containing CryptTextExtension subclasses.
+
+### Extension Hooks
+| Hook | Purpose | Return Value |
+|------|---------|--------------|
+| `getTopLevelMenus()` | Add top-level menus | List<JMenu> or null |
+| `getMenuItems(topLevelMenu)` | Add items to existing menu | List<JMenuItem> or null |
+| `fileWillLoad(File)` | Veto file loads | boolean (true=allow) |
+| `fileWillSave(File, newContents, destFile)` | Veto file saves | boolean (true=allow) |
+
+### Built-in Extensions
+1. **DirTreeExtension**: Directory tree panel on left, double-click to open files
+2. **StatusBarExtension**: Status bar at bottom, shows file info, encryption metadata
+3. **TestExtension**: For internal testing only (enabled via `-DenableTestExtension`)
+
+## 9. Configuration & Settings Files
+
+### AppConfig Properties
+Properties file: `~/.CryptText/CryptText.props`
+
+**General Settings**
+- `UI.General.singleInstance` - Enable single-instance mode
+- `UI.General.showFullPathInTitle` - Show full file path in title bar
+- `UI.General.recentFilesLimit` - Number of recent files
+
+**Editor Settings**
+- `UI.Editor.editorFont` - Editor font
+- `UI.Editor.gutterFont` - Line number font
+- `UI.Editor.showLineNumbers` - Show line number gutter
+- `UI.Editor.overrideLaF` - Use custom editor colors
+- `UI.Editor.colorTheme` - Color theme
+- `UI.Editor.editorBackground` - Editor background color
+- `UI.Editor.editorForeground` - Editor foreground color
+- `UI.Editor.gutterBackground` - Gutter background color
+- `UI.Editor.gutterForeground` - Gutter foreground color
+
+**Tab Settings**
+- `UI.Editor tabs.showLockIcons` - Show padlock on encrypted files
+- `UI.Editor tabs.tabIconSize` - Padlock icon size
+- `UI.Editor tabs.closeLastTabExits` - Exit when last tab closed
+- `UI.Editor tabs.restoreTabsOnStartup` - Restore tabs from last session
+
+**Keyboard Shortcuts** (Keystrokes.*)
+Default: Ctrl+N (new), Ctrl+O (open), Ctrl+S (save), Ctrl+D (crypt), F7 (forget), Ctrl+P (properties), Ctrl+E (extensions), Ctrl+L (log), Ctrl+A (about), Ctrl+Q (exit)
+
+### Application Directories
+- **INSTALL_DIR**: Installation directory (null if not installed via installer)
+- **SETTINGS_DIR**: `~/.CryptText/` (user settings)
+- **EXTENSIONS_DIR**: `~/.CryptText/extensions/` (extension jars)
+- **UPDATE_SOURCES_FILE**: `~/.CryptText/update_sources.json` (optional, for extension discovery)
+
+### Resource Files
+- **logging.properties** - Java logging configuration
+- **file_header.txt** - Encrypted file wrapper header
+- **ReleaseNotes.txt** - Version history
+- **images/** - Icons and logos
+
+## 10. Code Conventions and Patterns
+
+### Design Patterns Used
+
+1. **Singleton**: MainWindow, AppConfig, CryptTextExtensionManager
+   - Private constructor + static getInstance() method
+   
+2. **Observer/Listener**: Text events, UI updates
+   - Thread-safe with CopyOnWriteArrayList
+   
+3. **Action Pattern**: UI commands
+   - Extend javax.swing.AbstractAction
+   - Integrated with KeyStrokeManager
+   
+4. **Manager/Controller**: TextManager, MenuManager, RecentFilesManager
+   
+5. **Model-View Separation**: Clear separation of concerns
+
+### Naming Conventions
+- **Packages**: `ca.corbett.crypttext.[subsystem]` (lowercase)
+- **Classes**: PascalCase
+- **Methods**: camelCase
+- **Constants**: UPPER_SNAKE_CASE
+- **Properties**: Hierarchical dot notation
+
+### Exception Handling
+- **DecryptionFailedException**: Password/data validation failures
+- **VetoException**: Extension veto signaling
+- **Logging**: java.util.logging.Logger
+
+### Thread Safety
+- All Swing operations on EDT
+- SwingUtilities.invokeLater() for cross-thread updates
+- CopyOnWriteArrayList for listener collections
+
+### Immutability
+- Text class is immutable
+- Models represent immutable snapshots
+- Modification returns new instances or fires listener events
+
+## 11. CI/Build Files
+
+**Status**: No GitHub Actions configured
+
+To add CI/CD, create:
+- `.github/workflows/maven.yml` for build/test automation
+- Consider separate workflow for Linux installer packaging
+
+## 12. README Content Summary
+
+- **Overview**: User-friendly encrypted text editor
+- **Installation**: Linux installer tarball or Maven source build
+- **User Guide**: Editor usage, encryption workflow, configuration
+- **Features**: Look & Feel, editor settings, tab settings, keyboard shortcuts
+- **Built-in Extensions**: StatusBar, DirTree
+- **Built-in Windows/Actions**: Log Console
+- **Extension Development**: Reference to swing-extras API
+- **Repository**: GitHub issues for bugs/features
+- **License**: MIT License
+
+## 13. Version Class Structure
+
+```java
+public class Version {
+    // Application Info
+    public static String NAME = "CryptText";
+    public static String VERSION = "1.0";
+    public static String FULL_NAME = "CryptText 1.0";
+    public static String COPYRIGHT = "Copyright © 2026 Steve Corbett";
+    public static String PROJECT_URL = "https://github.com/scorbo2/crypttext";
+    public static String LICENSE = "https://opensource.org/license/mit";
+    
+    // Directory Paths (initialized in static block)
+    public static final File INSTALL_DIR;          // null if not installed
+    public static final File SETTINGS_DIR;         // ~/.CryptText/
+    public static final File UPDATE_SOURCES_FILE;  // null if not provided
+    public static final File EXTENSIONS_DIR;       // ~/.CryptText/extensions/
+    
+    public static AboutInfo getAboutInfo();
+}
+```
+
+Static initialization reads system properties and creates directories as needed.
+
+## 14. AppConfig Architecture
+
+```java
+public class AppConfig extends AppProperties<CryptTextExtension> {
+    public static AppConfig getInstance();
+    public String getLookAndFeelClassName();
+    public boolean isSingleInstanceEnabled();
+    public static String peek(String propName);
+    public Action getNewTabAction();
+    // ... action getters for all commands
+    public List<KeyStrokeProperty> getKeyStrokeProperties();
+}
+```
+
+**Key Design Points**:
+- Extends swing-extras AppProperties
+- Generic over CryptTextExtension
+- Centralizes all UI actions
+- Integrates with extension manager
+- Properties loaded from `~/.CryptText/CryptText.props`
+
+**Configuration Flow**: Main.main() → Load and activate extensions → AppConfig.getInstance().load() → Read properties file and create/update actions → Switch Look & Feel on EDT → Coordinate with extensions
+
+## 15. Important Notes for Development
+
+### Swing Development
+- All GUI updates on EDT via SwingUtilities.invokeLater()
+- JTextPane for rich text editing in tabs
+- Look & Feel changes require LAF switch + UI reload
+
+### Encryption
+- Passwords are memory-sensitive
+- Decryption failures = wrong password OR corrupted data
+- AES-GCM provides authenticated encryption to detect tampering
+- Argon2 intentionally slow for security
+
+### Extension Development
+- Loaded from jar files in extensions directory
+- Load order matters (alphabetically by default)
+- Can veto file operations via `CryptTextExtension.fileWillLoad/fileWillSave`
+- Have access to MainWindow static methods
+
+### Listener Pattern
+- Thread-safe (CopyOnWriteArrayList)
+- `CryptTextExtension.fileWillLoad/fileWillSave` provide extension veto hooks (internally backed by `TextWillLoad/TextWillSave` in `TextManager` via `EditorTabPane.buildTextManager()`)
+- UI listeners on EDT, data listeners may be cross-thread
+
+### File I/O
+- TextManager handles actual file reading/writing
+- Encrypted files wrapped with header before base64 encoding
+- Recent files list in `~/.CryptText/recent_files`
+- Tab state persisted
+
+## 16. Useful Commands
+
+```bash
+mvn clean package                           # Build project
+mvn test                                    # Run all tests
+mvn test -Dtest=CryptUtilTest              # Run specific test
+mvn clean package && java -jar target/crypttext-1.0.jar  # Build & run
+find src -name "*.java" | xargs wc -l      # Count lines of code
+```
+
+## 17. Codebase Metrics
+
+- **Total Lines of Code**: ~4,084 (source only)
+- **Java Version**: 17
+- **Test Classes**: 3 (CryptUtilTest, TextManagerTest, RecentFilesManagerTest)
+- **Main Packages**: 8
+- **Built-in Extensions**: 3 (DirTree, StatusBar, Test)
+
+---
+
+*For latest information: https://github.com/scorbo2/crypttext*

--- a/src/main/java/ca/corbett/crypttext/extensions/CryptTextExtensionManager.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/CryptTextExtensionManager.java
@@ -4,6 +4,7 @@ import ca.corbett.crypttext.Version;
 import ca.corbett.crypttext.crypt.CryptMetadata;
 import ca.corbett.crypttext.crypt.EncryptedText;
 import ca.corbett.crypttext.extensions.builtin.DirTreeExtension;
+import ca.corbett.crypttext.extensions.builtin.ImmersiveModeExtension;
 import ca.corbett.crypttext.extensions.builtin.StatusBarExtension;
 import ca.corbett.crypttext.extensions.builtin.TestExtension;
 import ca.corbett.crypttext.ui.TabStateManager;
@@ -66,6 +67,7 @@ public class CryptTextExtensionManager extends ExtensionManager<CryptTextExtensi
     public void loadAll() {
         // Load our built-in extensions first:
         addExtension(new DirTreeExtension(), true);
+        addExtension(new ImmersiveModeExtension(), true);
         addExtension(new StatusBarExtension(), true);
 
         // TestExtension is a bit special... we won't show it at all unless you've gone

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeExtension.java
@@ -163,6 +163,7 @@ public class ImmersiveModeExtension extends CryptTextExtension implements Change
                 immersiveWindow.setVisible(false);
                 immersiveWindow.dispose();
                 immersiveWindow = null;
+                isImmersiveMode = false;
                 toggleMenuItem.setSelected(false);
             }
         }

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeExtension.java
@@ -1,0 +1,236 @@
+package ca.corbett.crypttext.extensions.builtin;
+
+import ca.corbett.crypttext.AppConfig;
+import ca.corbett.crypttext.Version;
+import ca.corbett.crypttext.extensions.CryptTextExtension;
+import ca.corbett.crypttext.ui.EditorTab;
+import ca.corbett.crypttext.ui.MainWindow;
+import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.LookAndFeelManager;
+import ca.corbett.extras.MessageUtil;
+import ca.corbett.extras.io.KeyStrokeManager;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.extras.properties.KeyStrokeProperty;
+import ca.corbett.extras.properties.LabelProperty;
+
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.Component;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * An experimental extension to enable "immersive mode", where we'll hide
+ * all UI elements except the editor, for a distraction-free writing experience.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class ImmersiveModeExtension extends CryptTextExtension implements ChangeListener {
+
+    private static final Logger log = Logger.getLogger(ImmersiveModeExtension.class.getName());
+
+    private static final String TOGGLE_PROP = AppConfig.KEYSTROKE_PREFIX + "General.immersiveModeToggle";
+    private static final String ESC_PROP = AppConfig.KEYSTROKE_PREFIX + "General.immersiveModeExit";
+    private static final String INTRO_LABEL_PROP = "Immersive Mode.Options.introLabel";
+    private static final String MONITOR_PROP = "Immersive Mode.Options.monitorIndex";
+
+    private ImmersiveModeWindow immersiveWindow;
+    private MessageUtil messageUtil;
+    private final ImmersiveModeAction toggleAction;
+    private final EscapeAction exitAction;
+    private final JCheckBoxMenuItem toggleMenuItem;
+    private final AppExtensionInfo extInfo;
+    private boolean isImmersiveMode;
+
+    public ImmersiveModeExtension() {
+        extInfo = new AppExtensionInfo.Builder("Immersive Mode")
+                .setVersion(Version.VERSION)
+                .setTargetAppName(Version.NAME)
+                .setTargetAppVersion(Version.VERSION)
+                .setShortDescription("Hides all UI elements except the editor")
+                .setLongDescription("Enables an immersive mode that hides all UI elements " +
+                                            "except the text editor, for a distraction-free writing experience.")
+                .build();
+        toggleAction = new ImmersiveModeAction();
+        exitAction = new EscapeAction();
+        toggleMenuItem = new JCheckBoxMenuItem(toggleAction);
+        toggleMenuItem.setSelected(false);
+    }
+
+    @Override
+    public AppExtensionInfo getInfo() {
+        return extInfo;
+    }
+
+    @Override
+    public void onActivate() {
+        immersiveWindow = null;
+        isImmersiveMode = false;
+        LookAndFeelManager.addChangeListener(this);
+    }
+
+    @Override
+    public void onDeactivate() {
+        exitAction.actionPerformed(null); // make sure we exit immersive mode if we're currently in it
+        LookAndFeelManager.removeChangeListener(this);
+    }
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        // Make sure our menu item reflects changes to look and feel:
+        SwingUtilities.updateComponentTreeUI(toggleMenuItem);
+    }
+
+    @Override
+    protected List<AbstractProperty> createConfigProperties() {
+        List<AbstractProperty> props = new ArrayList<>();
+
+        props.add(new KeyStrokeProperty(TOGGLE_PROP, "Immersive Mode:",
+                                        KeyStrokeManager.parseKeyStroke("F11"),
+                                        toggleAction)
+                          .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(ESC_PROP, "Exit immersion:",
+                                        KeyStrokeManager.parseKeyStroke("ESC"),
+                                        exitAction)
+                          .setAllowBlank(true));
+
+        props.add(new LabelProperty(INTRO_LABEL_PROP,
+                                    "<html>Immersive mode brings the current editor" +
+                                            "<br>into full-screen mode, hiding all other " +
+                                            "<br>UI elements for a distraction-free" +
+                                            "<br>writing experience.</html>"));
+
+        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice[] gs = ge.getScreenDevices();
+        List<String> options = new ArrayList<>(gs.length);
+        options.add("Primary monitor");
+        for (int i = 1; i < gs.length; i++) { // All monitors after index 0 are secondary
+            options.add("Secondary monitor " + i);
+        }
+        props.add(new ComboProperty<>(MONITOR_PROP, "Monitor:", options, 0, false)
+                          .setHelpText("If the selected monitor is invalid, the primary will be used."));
+
+        return props;
+    }
+
+    @Override
+    protected void loadJarResources() {
+        // Nothing to load here
+    }
+
+    @Override
+    public List<JMenuItem> getMenuItems(String topLevelMenu) {
+        if (topLevelMenu.equals("Edit")) { // we should probably have a "view" menu...
+            List<JMenuItem> items = new ArrayList<>();
+            items.add(toggleMenuItem);
+            return items;
+        }
+
+        return null;
+    }
+
+    private int getConfiguredMonitorIndex() {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(MONITOR_PROP);
+        if (prop instanceof ComboProperty<?> comboProp) {
+            return comboProp.getSelectedIndex();
+        }
+        return 0; // default to primary monitor
+    }
+
+    /**
+     * A simple action to immediately exit immersive mode if it's currently active.
+     */
+    private class EscapeAction extends EnhancedAction {
+
+        public EscapeAction() {
+            super("Exit Immersion");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (immersiveWindow != null) {
+                immersiveWindow.setVisible(false);
+                immersiveWindow.dispose();
+                immersiveWindow = null;
+                toggleMenuItem.setSelected(false);
+            }
+        }
+    }
+
+    /**
+     * A simple action to toggle immersive mode on and off.
+     * Currently, we create an undecorated JWindow, and duplicate the current
+     * tab into a new EditorTab inside that window. Any changes that are made
+     * in the immersive window are synced back to the main window automatically.
+     */
+    private class ImmersiveModeAction extends EnhancedAction {
+
+        public ImmersiveModeAction() {
+            super("Toggle Immersive Mode");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Component c = MainWindow.getInstance().getEditorTabPane().getCurrentTab();
+            if (!(c instanceof EditorTab editorTab)) {
+                getMessageUtil().info("No editor tab is selected.");
+                return;
+            }
+
+            isImmersiveMode = !isImmersiveMode;
+            toggleMenuItem.setSelected(isImmersiveMode);
+
+            if (isImmersiveMode) {
+                // If this is somehow invoked when we already have one, dispose it:
+                if (immersiveWindow != null) {
+                    immersiveWindow.setVisible(false);
+                    immersiveWindow.dispose();
+                    immersiveWindow = null;
+                }
+
+                // Fire up a new one:
+                immersiveWindow = new ImmersiveModeWindow(MainWindow.getInstance(),
+                                                          editorTab,
+                                                          getConfiguredMonitorIndex());
+
+                // Listen for close events so we can update our state accordingly:
+                immersiveWindow.addWindowListener(new WindowAdapter() {
+                    @Override
+                    public void windowClosed(WindowEvent windowEvent) {
+                        isImmersiveMode = false;
+                        toggleMenuItem.setSelected(false);
+                    }
+                });
+
+                immersiveWindow.setVisible(true);
+            }
+
+            else {
+                // Shut down and close:
+                if (immersiveWindow != null) {
+                    immersiveWindow.setVisible(false);
+                    immersiveWindow.dispose();
+                    immersiveWindow = null;
+                }
+            }
+        }
+    }
+
+    private MessageUtil getMessageUtil() {
+        if (messageUtil == null) {
+            messageUtil = new MessageUtil(MainWindow.getInstance(), log);
+        }
+        return messageUtil;
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -119,14 +119,12 @@ class ImmersiveModeWindow extends JWindow {
             }
             // Ensure the cloned tab releases its own resources.
             clonedTab.dispose();
-            clonedTab = null;
         }
 
         // Break references to the temporary EditorTabPane so any associated listeners
         // can be garbage-collected once this window is disposed.
-        if (immersiveEditorTabPane != null) {
-            immersiveEditorTabPane.removeAll();
-            immersiveEditorTabPane = null;
+        if (tabPane != null) {
+            tabPane.removeAll();
         }
 
         super.dispose();

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -1,0 +1,154 @@
+package ca.corbett.crypttext.extensions.builtin;
+
+import ca.corbett.crypttext.AppConfig;
+import ca.corbett.crypttext.ui.BlockCursor;
+import ca.corbett.crypttext.ui.EditorTab;
+import ca.corbett.crypttext.ui.EditorTabPane;
+import ca.corbett.crypttext.ui.MainWindow;
+
+import javax.swing.JWindow;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.util.logging.Logger;
+
+/**
+ * Represents a full-screen window that shows a single editor tab with no UI clutter,
+ * for an immersive reading or writing experience. This is used internally by the
+ * ImmersiveModeExtension.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+class ImmersiveModeWindow extends JWindow {
+
+    private static final Logger log = Logger.getLogger(ImmersiveModeWindow.class.getName());
+
+    private final EditorTab sourceTab;
+    private final EditorTab clonedTab;
+    private EditorTab.ContentChangeListener sourceTabListener;
+    private EditorTab.ContentChangeListener clonedTabListener;
+    private final EditorTabPane tabPane;
+
+    /**
+     * Creates a new ImmersiveModeWindow that clones the given sourceTab
+     * and attempts to display it full-screen on the given monitor index
+     * (0-based, where 0 is the primary monitor). If the given monitor
+     * index is invalid, the primary is used as a fallback.
+     */
+    public ImmersiveModeWindow(MainWindow owner, EditorTab sourceTab, int monitorIndex) {
+        super(owner, getGraphicsConfig(monitorIndex));
+        tabPane = new EditorTabPane();
+        tabPane.setTabHeaderVisible(false);
+        this.sourceTab = sourceTab;
+        this.clonedTab = new EditorTab(tabPane, sourceTab.getTabName(), sourceTab.getDiskContents());
+        tabPane.addTab(sourceTab.getTabName(), clonedTab);
+        setLayout(new BorderLayout());
+        add(tabPane, BorderLayout.CENTER);
+
+        copyTextPaneConfiguration();
+        configurePosition(monitorIndex);
+        configureTextListeners();
+    }
+
+    /**
+     * Sets up cosmetic properties in the cloned tab to match the source tab.
+     */
+    private void copyTextPaneConfiguration() {
+        final Color fg = sourceTab.getTextPane().getForeground();
+        clonedTab.getTextPane().setFont(sourceTab.getTextPane().getFont());
+        clonedTab.getTextPane().setBackground(sourceTab.getTextPane().getBackground());
+        clonedTab.getTextPane().setForeground(fg);
+
+        // Check for custom Caret settings:
+        final AppConfig appConfig = AppConfig.getInstance();
+        if (appConfig.isUseBlockCursor()) {
+            clonedTab.getTextPane().setCaret(new BlockCursor(appConfig.getCursorBlinkRate(), fg));
+        }
+        else {
+            clonedTab.getTextPane().setCaretColor(sourceTab.getTextPane().getForeground());
+            clonedTab.getTextPane().getCaret().setBlinkRate(appConfig.getCursorBlinkRate());
+        }
+    }
+
+    /**
+     * Invoked internally to make a best attempt to position ourselves full-screen
+     * on the given target monitor. There is no guarantee that this will work,
+     * because the given monitor index may no longer be valid. If we can't find
+     * it, we'll fall back to the primary monitor, which <i>should</i> always work.
+     */
+    private void configurePosition(int monitorIndex) {
+        // Figure out our target monitor:
+        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice[] gs = ge.getScreenDevices();
+        if (monitorIndex >= gs.length) {
+            monitorIndex = 0; // Default to primary monitor if index is out of bounds
+        }
+
+        log.info("I see that you have " + gs.length + " monitor(s) connected. " +
+                         "Attempting to position immersive window on monitor index " + monitorIndex + ".");
+
+        // Position ourselves for the whole screen:
+        GraphicsDevice gd = gs[monitorIndex];
+        GraphicsConfiguration gc = gd.getDefaultConfiguration();
+        Rectangle bounds = gc.getBounds();
+        setLocation(bounds.x, bounds.y);
+        setSize(bounds.width, bounds.height);
+
+        log.info("I've set location to (" + bounds.x + ", " + bounds.y + ") " +
+                         "and size to (" + bounds.width + "x" + bounds.height + ").");
+    }
+
+    /**
+     * Make sure our two text panes are kept in sync with one another.
+     */
+    private void configureTextListeners() {
+        // Here's what I want to do:
+        // sourceTab.addContentChangeListener(clonedTab::setMemoryContents);
+        // clonedTab.addContentChangeListener(sourceTab::setMemoryContents);
+        // The problem is that this will cause infinite loops.
+        // So, we have to be a little more clever than that.
+
+        // When the source tab changes, turn off the cloned tab's listener,
+        // update it, and then start listening again:
+        sourceTabListener = new EditorTab.ContentChangeListener() {
+            @Override
+            public void onContentChange(String newContent) {
+                clonedTab.removeContentChangeListener(clonedTabListener);
+                clonedTab.setMemoryContents(newContent);
+                clonedTab.addContentChangeListener(clonedTabListener);
+            }
+        };
+
+        // Do the same in the other direction for the cloned tab:
+        clonedTabListener = new EditorTab.ContentChangeListener() {
+            @Override
+            public void onContentChange(String newContent) {
+                sourceTab.removeContentChangeListener(sourceTabListener);
+                sourceTab.setMemoryContents(newContent);
+                sourceTab.addContentChangeListener(sourceTabListener);
+            }
+        };
+
+        // Start listening:
+        sourceTab.addContentChangeListener(sourceTabListener);
+        clonedTab.addContentChangeListener(clonedTabListener);
+
+        // Also listen for the source tab closing, so we can close ourselves if that happens:
+        sourceTab.addTabClosedListener(e -> {
+            // Stop listening to the source tab, since we're about to close ourselves:
+            sourceTab.removeContentChangeListener(sourceTabListener);
+            dispose();
+        });
+    }
+
+    private static GraphicsConfiguration getGraphicsConfig(int monitorIndex) {
+        GraphicsDevice[] gs = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+        if (monitorIndex >= gs.length) {
+            monitorIndex = 0;
+        }
+        return gs[monitorIndex].getDefaultConfiguration();
+    }
+}

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -105,6 +105,33 @@ class ImmersiveModeWindow extends JWindow {
                          "and size to (" + bounds.width + "x" + bounds.height + ").");
     }
 
+    @Override
+    public void dispose() {
+        // Tear down content listeners between source and cloned tabs to avoid leaks.
+        if (sourceTab != null && sourceTabListener != null) {
+            sourceTab.removeContentChangeListener(sourceTabListener);
+            sourceTabListener = null;
+        }
+        if (clonedTab != null) {
+            if (clonedTabListener != null) {
+                clonedTab.removeContentChangeListener(clonedTabListener);
+                clonedTabListener = null;
+            }
+            // Ensure the cloned tab releases its own resources.
+            clonedTab.dispose();
+            clonedTab = null;
+        }
+
+        // Break references to the temporary EditorTabPane so any associated listeners
+        // can be garbage-collected once this window is disposed.
+        if (immersiveEditorTabPane != null) {
+            immersiveEditorTabPane.removeAll();
+            immersiveEditorTabPane = null;
+        }
+
+        super.dispose();
+    }
+
     /**
      * Make sure our two text panes are kept in sync with one another.
      */

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -87,7 +87,8 @@ class ImmersiveModeWindow extends JWindow {
             monitorIndex = 0; // Default to primary monitor if index is out of bounds
         }
 
-        log.info("I see that you have " + gs.length + " monitor(s) connected. " +
+        // For debugging monitor selection:
+        log.fine("I see that you have " + gs.length + " monitor(s) connected. " +
                          "Attempting to position immersive window on monitor index " + monitorIndex + ".");
 
         // Position ourselves for the whole screen:
@@ -97,7 +98,8 @@ class ImmersiveModeWindow extends JWindow {
         setLocation(bounds.x, bounds.y);
         setSize(bounds.width, bounds.height);
 
-        log.info("I've set location to (" + bounds.x + ", " + bounds.y + ") " +
+        // More monitor debugging:
+        log.fine("I've set location to (" + bounds.x + ", " + bounds.y + ") " +
                          "and size to (" + bounds.width + "x" + bounds.height + ").");
     }
 

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -13,6 +13,8 @@ import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.logging.Logger;
 
 /**
@@ -139,10 +141,27 @@ class ImmersiveModeWindow extends JWindow {
         clonedTab.addContentChangeListener(clonedTabListener);
 
         // Also listen for the source tab closing, so we can close ourselves if that happens:
-        sourceTab.addTabClosedListener(e -> {
-            // Stop listening to the source tab, since we're about to close ourselves:
-            sourceTab.removeContentChangeListener(sourceTabListener);
+        final EditorTab.TabClosedListener tabClosedListener = e -> {
+            // Close this immersive window; cleanup will run in the windowClosed handler.
             dispose();
+        };
+        sourceTab.addTabClosedListener(tabClosedListener);
+
+        // Ensure that all listeners are removed when this window is disposed/closed,
+        // regardless of how it is closed (F11/ESC, tab close, etc.).
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                // Remove content-change listeners on both tabs:
+                if (sourceTabListener != null) {
+                    sourceTab.removeContentChangeListener(sourceTabListener);
+                }
+                if (clonedTabListener != null) {
+                    clonedTab.removeContentChangeListener(clonedTabListener);
+                }
+                // Remove the tab-closed listener from the source tab:
+                sourceTab.removeTabClosedListener(tabClosedListener);
+            }
         });
     }
 

--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/ImmersiveModeWindow.java
@@ -45,7 +45,7 @@ class ImmersiveModeWindow extends JWindow {
         tabPane = new EditorTabPane();
         tabPane.setTabHeaderVisible(false);
         this.sourceTab = sourceTab;
-        this.clonedTab = new EditorTab(tabPane, sourceTab.getTabName(), sourceTab.getDiskContents());
+        this.clonedTab = new EditorTab(tabPane, sourceTab.getTabName(), sourceTab.getMemoryContents());
         tabPane.addTab(sourceTab.getTabName(), clonedTab);
         setLayout(new BorderLayout());
         add(tabPane, BorderLayout.CENTER);

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -72,7 +72,7 @@ public class BlockCursor extends DefaultCaret {
      */
     @Override
     public void damage(Rectangle r) {
-        if (r == null && getComponent() == null) {
+        if (r == null || getComponent() == null) {
             return;
         }
         x = r.x;

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -67,11 +67,22 @@ public class EditorTab extends JPanel implements UIReloadable {
         void onContentChange(String newContent);
     }
 
+    /**
+     * Listeners can subscribe to receive notification when this tab is closed.
+     * Note that this event is not vetoable. Listeners are notified AFTER the
+     * tab is closed. This is informational.
+     */
+    @FunctionalInterface
+    public interface TabClosedListener {
+        void onTabClosed(EditorTab tab);
+    }
+
     private static final Logger log = Logger.getLogger(EditorTab.class.getName());
     private MessageUtil messageUtil;
 
     private final List<PositionListener> positionListeners;
     private final List<ContentChangeListener> contentChangeListeners;
+    private final List<TabClosedListener> tabClosedListeners;
     private final EditorTabPane ownerPane;
     private final JTextPane textPane; // stores our memoryContents
     private final JScrollPane scrollPane;
@@ -104,6 +115,7 @@ public class EditorTab extends JPanel implements UIReloadable {
         }
         this.positionListeners = new ArrayList<>();
         this.contentChangeListeners = new ArrayList<>();
+        this.tabClosedListeners = new ArrayList<>();
         this.ownerPane = ownerPane;
         this.name = name;
         textPane = new JTextPane();
@@ -252,6 +264,9 @@ public class EditorTab extends JPanel implements UIReloadable {
         if (ownerPane.closeTab(this)) {
             // Our request to close the tab was not canceled or vetoed, so we are actually closing:
             dispose();
+
+            // Notify listeners:
+            fireTabClosedEvent();
         }
     }
 
@@ -515,6 +530,15 @@ public class EditorTab extends JPanel implements UIReloadable {
     }
 
     /**
+     * Allows direct access to our enclosed JTextPane.
+     * It's a bit of a design smell to expose this, but some
+     * extensions may need to access it directly, for customization purposes.
+     */
+    public JTextPane getTextPane() {
+        return textPane;
+    }
+
+    /**
      * Reports whether this tab has unsaved changes.
      */
     public boolean isDirty() {
@@ -535,6 +559,16 @@ public class EditorTab extends JPanel implements UIReloadable {
      * Does NOT commit anything to disk.
      */
     public void setMemoryContents(String newText) {
+        if (newText == null) {
+            newText = "";
+        }
+
+        // Wonky case: if we are given text that exactly matches our current contents, do nothing:
+        if (newText.equals(getMemoryContents())) {
+            return;
+        }
+
+        // Otherwise, accept the new value and mark ourselves dirty:
         textPane.setText(newText);
         markDirty();
     }
@@ -881,6 +915,39 @@ public class EditorTab extends JPanel implements UIReloadable {
         catch (Exception e) {
             // If a listener throws a runtime exception, don't let it interfere with this EditorTab:
             log.warning("Failed to fire content changed event: " + e.getMessage());
+        }
+    }
+
+    public void addTabClosedListener(TabClosedListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
+        tabClosedListeners.add(listener);
+    }
+
+    public void removeTabClosedListener(TabClosedListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
+        tabClosedListeners.remove(listener);
+    }
+
+    private void fireTabClosedEvent() {
+        // If no one is listening, don't bother:
+        if (tabClosedListeners.isEmpty()) {
+            return;
+        }
+
+        // Notify listeners:
+        try {
+            // Iterate over a copy of the list to avoid ConcurrentModificationExceptions:
+            for (TabClosedListener listener : new ArrayList<>(tabClosedListeners)) {
+                listener.onTabClosed(this);
+            }
+        }
+        catch (Exception e) {
+            // If a listener throws a runtime exception, don't let it interfere with this EditorTab:
+            log.warning("Failed to fire tab closed event: " + e.getMessage());
         }
     }
 

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
 
 /**
@@ -113,9 +114,9 @@ public class EditorTab extends JPanel implements UIReloadable {
         if (diskContents == null) {
             throw new IllegalArgumentException("diskContents cannot be null");
         }
-        this.positionListeners = new ArrayList<>();
-        this.contentChangeListeners = new ArrayList<>();
-        this.tabClosedListeners = new ArrayList<>();
+        this.positionListeners = new CopyOnWriteArrayList<>();
+        this.contentChangeListeners = new CopyOnWriteArrayList<>();
+        this.tabClosedListeners = new CopyOnWriteArrayList<>();
         this.ownerPane = ownerPane;
         this.name = name;
         textPane = new JTextPane();

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTabPane.java
@@ -8,8 +8,8 @@ import ca.corbett.crypttext.text.Text;
 import ca.corbett.crypttext.text.TextManager;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.MessageUtil;
+import ca.corbett.extras.ToggleableTabbedPane;
 
-import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.io.File;
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class EditorTabPane extends JTabbedPane {
+public class EditorTabPane extends ToggleableTabbedPane {
 
     public static final String DEFAULT_TAB_NAME = "Untitled";
 

--- a/src/main/java/ca/corbett/crypttext/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/crypttext/ui/MainWindow.java
@@ -329,6 +329,16 @@ public final class MainWindow extends JFrame implements UIReloadable {
     }
 
     /**
+     * Allows direct access to our KeyStrokeManager.
+     * Extensions are strongly encouraged to expose KeyStrokeProperties
+     * via the usual property mechanism, rather than adding or modifying
+     * our KeyStrokeManager directly.
+     */
+    public KeyStrokeManager getKeyStrokeManager() {
+        return keyStrokeManager;
+    }
+
+    /**
      * Sets up our KeyStrokeManager with the appropriate KeyStrokes from app config.
      */
     private void setKeyStrokes() {

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -7,6 +7,7 @@ Version 1.1 - [TODO release date here]
   #58 - Allow drag and drop from OS file manager to open file(s).
   #57 - EditorTab: scroll to top when opening tabs.
   #56 - Add keyboard shortcuts for changing font size on the fly.
+  #55 - Add Immersive Mode for full-screen reading or writing.
   #54 - DirTree: allow configurable width.
   #52 - Undo support: make keystroke configurable + compound edits.
   #50 - Undo support: Ctrl+Z undoes the last edit in each editor tab.


### PR DESCRIPTION
This PR addresses issue #55 by adding an "immersive mode" (full-screen) extension. When invoked, the current editor tab (if any) is cloned and presented in a full-screen undecorated window on the monitor of the user's choosing. The cloned editor tab is kept in sync with the source editor tab, such that any change to the contents of either are immediately pushed to the other. All keyboard shortcuts are preserved, such that Ctrl+S will save the current contents. A toggle key (F11 by default) is added to switch in and out of immersive mode, and an immersion exit key (ESC by default) is added as an aid for users who trigger the mode accidentally and don't know how to exit it.

Unrelated changes also in this PR:
- added copilot instructions file for this repository (zero code impact)
- found and fixed a bug in `BlockCursor` that might result in NullPointerExceptions.
