### PR TITLE
Issue #78 - upgrade to swing-extras 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/crypttext/Main.java
+++ b/src/main/java/ca/corbett/crypttext/Main.java
@@ -2,6 +2,7 @@ package ca.corbett.crypttext;
 
 import ca.corbett.crypttext.extensions.CryptTextExtensionManager;
 import ca.corbett.crypttext.ui.MainWindow;
+import ca.corbett.extras.FallbackExceptionHandler;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.updates.UpdateManager;
@@ -32,6 +33,9 @@ public class Main {
     public static void main(String[] args) {
         // Before we do anything else, set up logging:
         configureLogging();
+
+        // Set up a fallback exception handler so that uncaught exceptions get logged properly:
+        FallbackExceptionHandler.register();
 
         // Peek at our config file to see if single instance mode is enabled:
         boolean isSingleInstanceEnabled = Boolean.parseBoolean(AppConfig.peek(AppConfig.SINGLE_INSTANCE_PROP));


### PR DESCRIPTION
This PR addresses issue #78 by upgrading the `swing-extras` dependency to the latest `2.9` version. This application can now take advantage of the new `FallbackExceptionHandler` utility.
