### PR TITLE
Issue #80 - update status bar on successful save

### DIFF
--- a/src/main/java/ca/corbett/crypttext/extensions/builtin/StatusBarExtension.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/builtin/StatusBarExtension.java
@@ -164,7 +164,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
      * Our actual status bar component.
      */
     private static class StatusBarComponent extends JPanel
-            implements EditorTab.PositionListener, EditorTab.ContentChangeListener {
+            implements EditorTab.PositionListener, EditorTab.ContentChangeListener, EditorTab.TabSavedListener {
         private static final String DEFAULT_POS = "Ln 1, Col 1";
         private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -231,7 +231,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
         /**
          * Updates our label content based on the given EditorTab.
          * Passing null is perfectly valid here, it means "no tab is currently selected".
-         * In that case, we'll blank our our labels.
+         * In that case, we'll blank out our labels.
          */
         public void setLabels(EditorTab tab) {
             if (tab == null) {
@@ -322,6 +322,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
             if (currentTab != null) {
                 currentTab.removePositionListener(this);
                 currentTab.removeContentChangeListener(this);
+                currentTab.removeTabSavedListener(this);
             }
 
             // It's possible that the tab pane might contain Components that are not EditorTabs.
@@ -330,6 +331,7 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
                 currentTab = editorTab;
                 currentTab.addPositionListener(this);
                 currentTab.addContentChangeListener(this);
+                currentTab.addTabSavedListener(this);
             }
             else {
                 currentTab = null;
@@ -364,6 +366,14 @@ public class StatusBarExtension extends CryptTextExtension implements ChangeList
         @Override
         public void onContentChange(String newContent) {
             updateTextStatsLabel(newContent);
+        }
+
+        @Override
+        public void onTabSaved(EditorTab tab, File savedFile) {
+            // If the currently selected tab was just saved, we need to update our file info labels, since the file on disk may have changed:
+            if (tab == currentTab) {
+                setLabels(currentTab);
+            }
         }
     }
 

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -1005,7 +1005,7 @@ public class EditorTab extends JPanel implements UIReloadable {
         tabSavedListeners.remove(listener);
     }
 
-    public void fireTabSavedEvent(File saveFile) {
+    private void fireTabSavedEvent(File saveFile) {
         // If no one is listening, don't bother:
         if (tabSavedListeners.isEmpty()) {
             return;

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -70,8 +70,9 @@ public class EditorTab extends JPanel implements UIReloadable {
 
     /**
      * Listeners can subscribe to receive notification when this tab is closed.
-     * Note that this event is not vetoable. Listeners are notified AFTER the
-     * tab is closed. This is informational.
+     * Note that this event is not vetoable. Listeners are notified during
+     * tab closure, immediately before dispose(). This is informational,
+     * and cannot be vetoed or canceled.
      */
     @FunctionalInterface
     public interface TabClosedListener {
@@ -282,11 +283,11 @@ public class EditorTab extends JPanel implements UIReloadable {
      */
     public void close() {
         if (ownerPane.closeTab(this)) {
-            // Our request to close the tab was not canceled or vetoed, so we are actually closing:
-            dispose();
-
             // Notify listeners:
             fireTabClosedEvent();
+
+            // Our request to close the tab was not canceled or vetoed, so we are actually closing:
+            dispose();
         }
     }
 

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -398,6 +398,8 @@ public class EditorTab extends JPanel implements UIReloadable {
                 // If we were a scratch file, we now have an actual name.
                 // If we weren't a scratch file, our name has likely changed.
                 setTabName(newFile.getName());
+
+                fireTabSavedEvent(diskContents.getSourceFile());
             }
             catch (VetoException ignored) {
                 // Save was vetoed by an extension!
@@ -456,6 +458,8 @@ public class EditorTab extends JPanel implements UIReloadable {
 
                 // Overwrite any CryptMetadata we had and immediately forget our password:
                 setCryptMetadata(new DefaultCryptMetadata(false));
+
+                fireTabSavedEvent(diskContents.getSourceFile());
             }
             catch (VetoException ignored) {
                 // Save was vetoed by an extension!

--- a/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
+++ b/src/main/java/ca/corbett/crypttext/ui/EditorTab.java
@@ -78,12 +78,24 @@ public class EditorTab extends JPanel implements UIReloadable {
         void onTabClosed(EditorTab tab);
     }
 
+    /**
+     * Listeners can subscribe to receive notification when save() is successfully
+     * invoked on this tab. The supplied File is the file that was actually written to,
+     * which may differ from the source file if this tab was created from a scratch file,
+     * or if "save as" was used.
+     */
+    @FunctionalInterface
+    public interface TabSavedListener {
+        void onTabSaved(EditorTab tab, File savedFile);
+    }
+
     private static final Logger log = Logger.getLogger(EditorTab.class.getName());
     private MessageUtil messageUtil;
 
     private final List<PositionListener> positionListeners;
     private final List<ContentChangeListener> contentChangeListeners;
     private final List<TabClosedListener> tabClosedListeners;
+    private final List<TabSavedListener> tabSavedListeners;
     private final EditorTabPane ownerPane;
     private final JTextPane textPane; // stores our memoryContents
     private final JScrollPane scrollPane;
@@ -118,6 +130,7 @@ public class EditorTab extends JPanel implements UIReloadable {
         this.positionListeners = new CopyOnWriteArrayList<>();
         this.contentChangeListeners = new CopyOnWriteArrayList<>();
         this.tabClosedListeners = new CopyOnWriteArrayList<>();
+        this.tabSavedListeners = new CopyOnWriteArrayList<>();
         this.ownerPane = ownerPane;
         this.name = name;
         textPane = new JTextPane();
@@ -284,6 +297,10 @@ public class EditorTab extends JPanel implements UIReloadable {
         UIReloadAction.getInstance().unregisterReloadable(this); // stop listening
         undoableEditListener.flush(); // commit any pending group and stop the timer
         textPane.getDocument().removeUndoableEditListener(undoableEditListener);
+        positionListeners.clear();
+        contentChangeListeners.clear();
+        tabClosedListeners.clear();
+        tabSavedListeners.clear();
     }
 
     /**
@@ -336,6 +353,8 @@ public class EditorTab extends JPanel implements UIReloadable {
         // but it makes sense when you consider the above flow: the in-memory contents were
         // successfully encrypted and saved to disk.
         markClean();
+
+        fireTabSavedEvent(diskContents.getSourceFile());
     }
 
     /**
@@ -969,6 +988,39 @@ public class EditorTab extends JPanel implements UIReloadable {
         catch (Exception e) {
             // If a listener throws a runtime exception, don't let it interfere with this EditorTab:
             log.warning("Failed to fire tab closed event: " + e.getMessage());
+        }
+    }
+
+    public void addTabSavedListener(TabSavedListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
+        tabSavedListeners.add(listener);
+    }
+
+    public void removeTabSavedListener(TabSavedListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
+        tabSavedListeners.remove(listener);
+    }
+
+    public void fireTabSavedEvent(File saveFile) {
+        // If no one is listening, don't bother:
+        if (tabSavedListeners.isEmpty()) {
+            return;
+        }
+
+        // Notify listeners:
+        try {
+            // Iterate over a copy of the list to avoid ConcurrentModificationExceptions:
+            for (TabSavedListener listener : new ArrayList<>(tabSavedListeners)) {
+                listener.onTabSaved(this, saveFile);
+            }
+        }
+        catch (Exception e) {
+            // If a listener throws a runtime exception, don't let it interfere with this EditorTab:
+            log.warning("Failed to fire tab saved event: " + e.getMessage());
         }
     }
 

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,8 @@ CryptText Release Notes
 ==============================================
 
 Version 1.2 - [TODO release date] Maintenance release
+  #80 - Fix bug in status bar (update on save)
+  #78 - Upgrade to swing-extras 2.9
 
 Version 1.1 - [2026-03-13] Maintenance release
   #69 - Make undo/redo smarter about updating clean/dirty status.


### PR DESCRIPTION
This PR addresses issue #80 by fixing a bug in the `StatusBarExtension` where the status bar would not be updated for the current tab after a successful save.