### PR TITLE
Issue #82 - better error checking when loading files

### DIFF
--- a/src/main/java/ca/corbett/crypttext/text/TextManager.java
+++ b/src/main/java/ca/corbett/crypttext/text/TextManager.java
@@ -141,8 +141,9 @@ public class TextManager {
      * Extensions can veto this operation! A VetoException will be thrown if that happens.
      * Calling code must gracefully respond to this.
      * <p>
-     * No check is done here to make sure the given file is a valid text file!
-     * Such validation can be done ahead of time with the TextFileDetector class.
+     * A basic check is done (via TextFileDetector) to see if the given file appears to
+     * be a text file, before the load is attempted. If it doesn't appear to be a text file, an IOException
+     * is thrown with a helpful message.
      * </p>
      *
      * @param file The file to load from. Must be a valid, readable file (not a directory).

--- a/src/main/java/ca/corbett/crypttext/text/TextManager.java
+++ b/src/main/java/ca/corbett/crypttext/text/TextManager.java
@@ -3,6 +3,7 @@ package ca.corbett.crypttext.text;
 import ca.corbett.crypttext.Version;
 import ca.corbett.crypttext.VetoException;
 import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.extras.io.TextFileDetector;
 
 import java.io.File;
 import java.io.IOException;
@@ -160,6 +161,11 @@ public class TextManager {
         Text newText = fromCache(file);
         if (newText != null) {
             return newText;
+        }
+
+        // Let's try to see if it's actually a text file before we proceed:
+        if (!TextFileDetector.isTextFile(file)) {
+            throw new IOException("The given file does not appear to be a text file: " + file.getAbsolutePath());
         }
 
         // Give listeners a chance to veto:

--- a/src/main/java/ca/corbett/crypttext/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/crypttext/ui/MainWindow.java
@@ -38,6 +38,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.MalformedInputException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -152,6 +153,15 @@ public final class MainWindow extends JFrame implements UIReloadable {
 
             // If so, let's load each one into a new tab:
             try {
+                // The swing-extras library gives us an easy way to do a quick sanity check on
+                // our input arguments, to make sure they are valid text files before we try to load them:
+                if (!TextFileDetector.isTextFile(argFile)) {
+                    getMessageUtil().error("Not a text file",
+                                           "The file " + arg + " does not appear to be a text file.");
+                    continue;
+                }
+
+                // Now it is reasonably safe to try to load it:
                 Text text = editorTabPane.getTextManager().fromFile(argFile);
                 editorTabPane.clearIfScratch(); // Don't leave the default "Untitled" tab open if we load something.
                 editorTabPane.newTextTab(text, argFile.getName());
@@ -160,7 +170,19 @@ public final class MainWindow extends JFrame implements UIReloadable {
                 // An extension vetoed the load!
                 // Just skip it - TextManager has already logged the veto.
             }
+            catch (MalformedInputException mfe) {
+                // Java's NIO classes will throw this if the file is not valid text.
+                // Our TextFileDetector will probably weed those ones out above, but
+                // let's be extra careful, so that we don't give the user a meaningless error message.
+                getMessageUtil().info("Unable to open file",
+                                      "The file " + arg + " does not appear to be a valid text file.");
+
+                // We can log the actual message we got, but it probably won't mean much to the user:
+                logger.warning("MalformedInputException while trying to load file \""
+                                       + arg + "\": " + mfe.getMessage());
+            }
             catch (IOException | IllegalArgumentException e) {
+                // For all other errors, we can just show whatever we get from the exception:
                 getMessageUtil().error("File error",
                                        "An error occurred while trying to open the file:\n" + arg + "\n\n" +
                                                "Error message: " + e.getMessage(),

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,6 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.2 - [TODO release date] Maintenance release
+  #82 - Better error messaging for startup arguments
   #80 - Fix bug in status bar (update on save)
   #78 - Upgrade to swing-extras 2.9
 

--- a/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt
@@ -2,7 +2,7 @@ CryptText Release Notes
 ==============================================
 
 Version 1.2 - [TODO release date] Maintenance release
-  #82 - Better error messaging for startup arguments
+  #82 - Better error messaging when loading non-text files
   #80 - Fix bug in status bar (update on save)
   #78 - Upgrade to swing-extras 2.9
 

--- a/src/test/java/ca/corbett/crypttext/text/TextManagerTest.java
+++ b/src/test/java/ca/corbett/crypttext/text/TextManagerTest.java
@@ -248,6 +248,31 @@ class TextManagerTest {
         assertEquals(0, textManager.size());
     }
 
+    @Test
+    void testFromFile_withBinaryFile_shouldThrowIOException() {
+        // GIVEN a file containing null bytes (obviously not a text file):
+        File binaryFile = tempDir.resolve("binary.dat").toFile();
+        try {
+            Files.write(binaryFile.toPath(), new byte[]{0, 1, 2, 3, 4});
+        }
+        catch (IOException e) {
+            fail("Failed to create binary test file: " + e.getMessage());
+        }
+
+        // WHEN we try to load it with fromFile:
+        try {
+            textManager.fromFile(binaryFile);
+            fail("Was expecting an IOException but didn't get one!");
+        }
+        catch (IOException e) {
+            // THEN we should get an IOException because the file is not valid text:
+            assertTrue(e.getMessage().contains("does not appear to be a text file"));
+        }
+        catch (VetoException ve) {
+            fail("Unexpected VetoException when loading binary file: " + ve.getMessage());
+        }
+    }
+
     // ==================== SaveText Tests ====================
 
     @Test


### PR DESCRIPTION
This PR addresses issue #82 by adding better heuristics to the file load code paths, to better detect and prevent attempts to load non-text files into the editor. A more friendly error message is shown, instead of relying on Java's NIO classes to supply a message for us.