### PR TITLE
Issue #90 - add update_sources.json

### DIFF
--- a/installer.props
+++ b/installer.props
@@ -26,7 +26,7 @@ OUTPUT_DIR=target
 TO_COPY="target/lib"
 TO_COPY="${TO_COPY} src/main/resources/ca/corbett/crypttext/ReleaseNotes.txt"
 
-# TODO CryptText v1 has no external application extensions yet... uncomment this later
-#TO_COPY="${TO_COPY} update_sources.json"
+# Allow dynamic discovery of application extensions and new versions:
+TO_COPY="${TO_COPY} update_sources.json"
 
 TO_COPY="${TO_COPY} src/main/resources/ca/corbett/crypttext/images/logo.png"

--- a/update_sources.json
+++ b/update_sources.json
@@ -1,0 +1,18 @@
+{
+  "applicationName": "CryptText",
+  "updateSources": [
+    {
+      "name": "local filesystem",
+      "baseUrl": "file:${user.home}/Software/sc-releases/apps-dist/CryptText",
+      "versionManifest": "version_manifest.json",
+      "publicKey": "public.key"
+    },
+    {
+      "name": "www.corbett.ca",
+      "baseUrl": "http://www.corbett.ca/apps/CryptText",
+      "versionManifest": "version_manifest.json",
+      "publicKey": "public.key"
+    }
+  ],
+  "isAllowSnapshots": false
+}


### PR DESCRIPTION
This PR addresses issue #90 by adding an `update_sources.json` to the project, and ensuring that it is included in the installer tarball.

It turns out that the required wiring for our extension manager and about dialog was already in place (in the `parseUpdateSources()` method in `Main`). All that was missing was the json file itself. Verified with a quick run that the file is now detected and parsed successfully on startup, and dynamic application extension discovery is now working properly.
