### PR TITLE
Issue #94 - upgrade swing-extras and java versions

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="temurin-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <version>1.3-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/crypttext/Main.java
+++ b/src/main/java/ca/corbett/crypttext/Main.java
@@ -67,7 +67,7 @@ public class Main {
                    new Object[]{extManager.getLoadedExtensionCount(), extManager.getEnabledLoadedExtensions().size()});
 
         // Load our application configuration:
-        AppConfig.getInstance().load();
+        AppConfig.getInstance().reinitialize();
 
         // Parse update sources if provided, to enable dynamic extension discovery:
         parseUpdateSources();

--- a/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
+++ b/src/main/java/ca/corbett/crypttext/ui/BlockCursor.java
@@ -4,6 +4,7 @@ import javax.swing.Timer;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
 import javax.swing.text.JTextComponent;
+import javax.swing.text.Position;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Rectangle;
@@ -92,7 +93,8 @@ public class BlockCursor extends DefaultCaret {
         if (isVisible() && getComponent() != null) {
             try {
                 // Get the target rectangle and set our color:
-                Rectangle r = getComponent().getUI().modelToView(getComponent(), getDot());
+                Rectangle r = getComponent().getUI().modelToView2D(getComponent(), getDot(), Position.Bias.Forward)
+                                            .getBounds();
                 g.setColor(cursorColor);
 
                 // In my testing, I find that r.width is always 0, and I don't know why.


### PR DESCRIPTION
This PR addresses issue #94 by implementing some upgrades for our upcoming `1.3` release:

- upgrade `swing-extras` to `3.0.0` (latest stable release)
- upgrade Java 17 to Java 25 (latest LTS)
- handle minor compatibility/deprecation issues in code